### PR TITLE
feat: Site Health Check tool, Algorithm Updates refresh, Setup simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ We take your data security seriously. This tool is designed to be **local-first*
 First, use the interactive wizard to validate your credentials and get your configuration:
 
 ```bash
-npx search-console-mcp-setup
+npx -y search-console-mcp setup
 ```
 
 The wizard will guide you through:
@@ -155,6 +155,7 @@ These are low-level tools designed to be used by other AI agents to build comple
 |------|-------------|
 | `sites_list` | List all verified sites. |
 | `sites_add` / `sites_delete` | Manage properties. |
+| `sites_health_check` | **[NEW]** Run a health check on one or all sites. Checks WoW performance, sitemaps, and anomalies. |
 | `sitemaps_list` / `sitemaps_submit` | Manage sitemaps. |
 
 ### Inspection & Validation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,6 +5,7 @@ This document outlines the planned features and improvements for this project.
 ## ✅ Completed
 
 ### v1.0.0 - Initial Release
+
 - Sites management (list, add, delete, get)
 - Sitemaps management (list, submit, delete, get)
 - Search Analytics queries with filtering
@@ -14,6 +15,7 @@ This document outlines the planned features and improvements for this project.
 - Error handling with user-friendly messages
 
 ### v1.1.0 - Documentation Resources
+
 - Embedded documentation as MCP resources
 - Dimensions reference (`docs://dimensions`)
 - Filters reference (`docs://filters`)
@@ -21,6 +23,7 @@ This document outlines the planned features and improvements for this project.
 - Common patterns & recipes (`docs://patterns`)
 
 ### v1.2.0 - Enhanced Analytics Tools
+
 - `analytics_compare_periods` - Compare two date ranges
 - `analytics_top_queries` - Top queries by clicks/impressions
 - `analytics_top_pages` - Top pages by clicks/impressions
@@ -28,6 +31,7 @@ This document outlines the planned features and improvements for this project.
 - Comprehensive README with installation guides
 
 ### v1.3.0 - More Prompts
+
 - `compare-performance` - Compare this week vs last week
 - `find-declining-pages` - Identify pages losing traffic
 - `keyword-opportunities` - Find low-CTR high-impression queries
@@ -35,36 +39,45 @@ This document outlines the planned features and improvements for this project.
 - `mobile-vs-desktop` - Compare device performance
 
 ### v1.4.0 - Additional Resources
+
 - `sitemaps://list/{siteUrl}` - List sitemaps for a site
 - `analytics://summary/{siteUrl}` - Performance summary for a site
 
 ### v1.5.0 - CI/CD & PageSpeed Integration
+
 - GitHub Actions CI workflow (Node 18/20/22)
 - Automated npm publish on release
 - `pagespeed_analyze` - PageSpeed Insights analysis
 - `pagespeed_core_web_vitals` - Core Web Vitals (LCP, FID, CLS, FCP, TTI, TBT)
 
 ### v1.8.0 - SEO Insights
+
 - `seo_recommendations` - Generate actionable SEO improvement suggestions
 - `seo_low_hanging_fruit` - Find high-impression keywords at positions 5-20
 - `seo_cannibalization` - Detect pages competing for the same keywords
 - `seo_quick_wins` - Find pages close to page 1 (positions 11-20)
 
 ### v1.9.0 - Schema Validator & Experience
-- `schema_validate` - Validate structured data (JSON-LD)
-- Enhanced Setup Wizard with project support and better UX
 
-### v1.10.0 - Advanced Analytics
+### v1.9.1 - Advanced Analytics
+
 - \`analytics_trends\` - Detect traffic trends (growing/declining)
 - \`analytics_anomalies\` - Identify unusual spikes or drops
 - \`analytics_by_country\` - Performance breakdown by country
 - \`analytics_search_appearance\` - Data by search appearance type
 
-### v1.11.0 - Attribution & Forecasting
+### v1.9.2 - Security & Docs Site
+
+- `schema_validate` - Validate structured data (JSON-LD)
+- Enhanced Setup Wizard with project support and better UX
 - \`analytics_drop_attribution\` - Device impact & Google Algorithm correlation
 - \`analytics_time_series\` - Dynamic rolling averages & trend forecasting
 - **Security Hardening**: Path traversal protection in setup wizard
 - **Expanded Documentation**: Algorithm updates reference (\`docs://algorithm-updates\`)
+
+### v1.9.3 - Schema Validator & Experience
+
+- `sites_health_check` - Check all sites for issues
 
 ---
 
@@ -75,16 +88,15 @@ _Nothing currently in progress_
 ---
 
 ## 📋 Planned
+
 ### v1.11.0 - Bulk Operations
 
-| Feature | Description |
-|---------|-------------|
+| Feature           | Description                       |
+| ----------------- | --------------------------------- |
 | `inspection_bulk` | Inspect multiple URLs in one call |
-| `sites_health_check` | Check all sites for issues |
+
 | Export to CSV/JSON | Export analytics data |
 | Batch URL status | Check indexing status for URL list |
-
-
 
 ### v2.0.0 - OAuth2 Support
 
@@ -98,13 +110,15 @@ _Nothing currently in progress_
 ## 🔮 Future Considerations
 
 ### Additional APIs
-| API | Use Case |
-|-----|----------|
-| Google Analytics 4 | Session/user data, conversion tracking |
-| Bing Webmaster Tools | Microsoft search performance |
-| Screaming Frog API | Technical SEO audits |
+
+| API                  | Use Case                               |
+| -------------------- | -------------------------------------- |
+| Google Analytics 4   | Session/user data, conversion tracking |
+| Bing Webmaster Tools | Microsoft search performance           |
+| Screaming Frog API   | Technical SEO audits                   |
 
 ### Monitoring & Alerts
+
 - Performance threshold alerts
 - Indexing issue notifications
 - Manual actions monitoring
@@ -112,6 +126,7 @@ _Nothing currently in progress_
 - Sitemap error tracking
 
 ### Reporting
+
 - Scheduled reports (daily/weekly/monthly)
 - Custom report templates
 - PDF/HTML report generation
@@ -119,6 +134,7 @@ _Nothing currently in progress_
 - Email digest summaries
 
 ### Developer Experience
+
 - Debug logging mode (`--verbose`)
 - Request/response caching (Redis support)
 - Rate limit handling with exponential backoff
@@ -126,6 +142,7 @@ _Nothing currently in progress_
 - GraphQL-style query builder
 
 ### Multi-Site Management
+
 - Site groups/tags
 - Cross-site comparison
 - Portfolio dashboards

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -45,7 +45,8 @@
           "tools/analytics",
           "tools/seo-intelligence",
           "tools/inspection",
-          "tools/sites-and-sitemaps"
+          "tools/sites-and-sitemaps",
+          "tools/site-health"
         ]
       },
       {

--- a/docs/getting-started/first-queries.md
+++ b/docs/getting-started/first-queries.md
@@ -35,6 +35,15 @@ This is where the power of the MCP shines. Instead of asking for data, ask for a
 
 The agent will use the `seo_quick_wins` tool, which performs a deterministic filter to identify the best opportunities.
 
+## Step 4: Run a Site Health Check
+
+Now try the health check tool to get an instant diagnostic across your properties.
+
+**User Prompt:**
+> "Run a health check on all my sites and tell me which ones need attention."
+
+The agent will use the `sites_health_check` tool to check performance trends, sitemap status, and traffic anomalies — returning a status of healthy, warning, or critical for each site.
+
 ## Tips for Success
 
 *   **Specify the Site:** Always include the `siteUrl` in your prompt if you have access to multiple sites.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -15,7 +15,7 @@ Setting up `search-console-mcp` is straightforward. You can run it directly usin
 The easiest way to get started is by using our built-in setup wizard:
 
 ```bash
-npx search-console-mcp-setup
+npx -y search-console-mcp setup
 ```
 
 This wizard will help you:

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -11,6 +11,7 @@ Unlike simple API wrappers, this project focuses on providing **SEO Intelligence
 
 *   **Advanced Analytics:** Go beyond basic queries with multi-dimensional analysis and rolling averages.
 *   **SEO Insights:** Deterministic detection of cannibalization, Striking Distance keywords, and "Low-Hanging Fruit."
+*   **Site Health Check:** Automated diagnostics across all your properties — performance trends, sitemap status, and anomaly detection in one call.
 *   **Site Management:** List, add, and verify site properties.
 *   **Sitemap Control:** List, submit, and delete sitemaps.
 *   **URL Inspection:** Check the indexing status of individual pages.

--- a/docs/prompts/claude.md
+++ b/docs/prompts/claude.md
@@ -27,6 +27,17 @@ My traffic for https://example.com has dropped recently.
 4. Act as a senior SEO consultant and attribute this drop to a specific cause (e.g., technical, algorithm, or seasonality).
 ```
 
+## The "Site Health Check" Prompt
+Use this to get an instant diagnostics overview.
+
+```markdown
+Run a health check across all my verified sites.
+1. Use the site health check tool to get the status of each property.
+2. For any site with "critical" or "warning" status, investigate the root cause.
+3. If there was a traffic drop, check if it correlates with a known Google algorithm update.
+4. Provide a prioritized action plan for the most affected sites.
+```
+
 ## Why these work well
 *   **Chained Tool Use:** These prompts encourage Claude to use multiple tools in sequence before answering.
 *   **Role Prompting:** By asking Claude to "Act as a senior SEO consultant," you improve the quality of the qualitative reasoning it adds to the quantitative data.

--- a/docs/prompts/cursor.md
+++ b/docs/prompts/cursor.md
@@ -23,6 +23,15 @@ Compare the queries discovered with the current <title> and <meta description> t
 Suggest improved, keyword-optimized titles that are likely to increase my CTR.
 ```
 
+## The "Health Check Dashboard" Prompt
+Use this to monitor all your sites from your IDE.
+
+```markdown
+Run a health check for https://example.com using the search-console MCP.
+Show me the overall status, week-over-week performance changes, and any sitemap errors.
+If there are issues, cross-reference with my local code to see if a recent deploy could have caused them.
+```
+
 ## Why these work well
 *   **Contextual Awareness:** Cursor knows your code. By using the MCP, it also knows your *results*. This bridge allows it to make code suggestions based on search performance.
 *   **Zero-Context Switching:** You don't have to leave your editor to know that your recent deploy slowed down your most important landing page.

--- a/docs/prompts/generic-agents.md
+++ b/docs/prompts/generic-agents.md
@@ -23,6 +23,16 @@ Useful if you manage multiple properties.
 3. Which site had the highest percentage growth in non-brand traffic?
 ```
 
+## The "Health Check" Prompt
+Monitor the health of one or all sites.
+
+```markdown
+1. Run a health check across all my Search Console properties.
+2. For each site, report the status (healthy / warning / critical) and any issues found.
+3. For sites with critical status, use the drop attribution tool to check for algorithm update correlation.
+4. Provide a ranked list of sites that need attention, with specific next steps for each.
+```
+
 ## Common Tips for Custom Agents
 
 *   **Specify Dimension:** When asking for analytics, specify if you want it by `query`, `page`, `country`, or `date`.

--- a/docs/tools/site-health.md
+++ b/docs/tools/site-health.md
@@ -1,0 +1,102 @@
+---
+title: "Site Health Check"
+description: "Automated health diagnostics for one or all Search Console properties."
+---
+
+The `sites_health_check` tool gives your AI agent the ability to perform a comprehensive, automated health check across your Search Console properties — or drill into a single site.
+
+## How It Works
+
+When invoked, the tool runs the following checks **in parallel** for each site:
+
+1.  **Week-over-Week Performance** — Compares clicks, impressions, CTR, and average position for the current 7-day period against the previous 7 days (with a 3-day data delay to account for GSC reporting lag).
+2.  **Sitemap Status** — Lists all submitted sitemaps and flags any with errors or warnings.
+3.  **Traffic Anomalies** — Uses statistical anomaly detection (Z-score, 14-day window) to surface unexpected traffic drops.
+
+The results are aggregated into a per-site report with an overall status:
+
+| Status | Meaning |
+|--------|---------|
+| `healthy` | No issues detected. |
+| `warning` | Minor issues found (e.g., moderate traffic decline, sitemap warnings, anomaly drops). |
+| `critical` | Severe problems (e.g., traffic down >30%, no traffic data, no sitemaps). |
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `siteUrl` | No | The URL of a specific site to check. If omitted, **all verified sites** are checked. |
+
+When checking all sites, results are sorted with **critical sites first**.
+
+## Report Structure
+
+Each site report contains:
+
+```json
+{
+  "siteUrl": "https://example.com",
+  "status": "warning",
+  "permissionLevel": "siteOwner",
+  "performance": {
+    "current": { "clicks": 400, "impressions": 8000, "ctr": 0.05, "position": 9 },
+    "previous": { "clicks": 500, "impressions": 10000, "ctr": 0.05, "position": 8 },
+    "changes": {
+      "clicks": -100, "clicksPercent": -20,
+      "impressions": -2000, "impressionsPercent": -20,
+      "ctr": 0, "ctrPercent": 0,
+      "position": 1, "positionPercent": 12.5
+    }
+  },
+  "sitemaps": {
+    "total": 1,
+    "withErrors": 0,
+    "withWarnings": 0,
+    "details": [
+      { "path": "https://example.com/sitemap.xml", "type": "sitemap", "isPending": false, "hasErrors": false }
+    ]
+  },
+  "anomalies": [],
+  "issues": [
+    "Traffic declining: clicks down 20.0% week-over-week",
+    "Visibility declining: impressions down 20.0% week-over-week"
+  ]
+}
+```
+
+## Issue Detection Rules
+
+The tool automatically flags the following:
+
+| Condition | Severity | Issue Message |
+|-----------|----------|---------------|
+| Clicks down ≥ 30% WoW | Critical | "Critical traffic drop: clicks down X% week-over-week" |
+| Clicks down ≥ 15% WoW | Warning | "Traffic declining: clicks down X% week-over-week" |
+| Impressions down ≥ 30% WoW | Critical | "Critical visibility drop: impressions down X% week-over-week" |
+| Impressions down ≥ 15% WoW | Warning | "Visibility declining: impressions down X% week-over-week" |
+| Position worsened by > 3 | Warning | "Average position worsened by X positions" |
+| Zero clicks & impressions | Critical | "No traffic data for the current period" |
+| No sitemaps submitted | Warning | "No sitemaps submitted" |
+| Sitemaps with errors | Warning | "N sitemap(s) have errors" |
+| Sitemaps with warnings | Warning | "N sitemap(s) have warnings" |
+| Anomaly drops in 14 days | Warning | "N traffic anomaly drop(s) detected" |
+
+## Example Agent Prompts
+
+#### Quick Health Check (Single Site)
+> "Run a health check on https://example.com. Summarize any issues and recommend next steps."
+
+#### Portfolio Health Overview
+> "Check the health of all my sites and give me a dashboard-style summary. Which sites need attention right now?"
+
+#### Weekly Monitoring Workflow
+> "Run a health check on all my sites. For any site with 'critical' status, investigate the cause using the drop attribution and URL inspection tools."
+
+## Integration with Other Tools
+
+The health check is designed to be a **starting point** for deeper analysis:
+
+*   **Critical traffic drops →** Follow up with `analytics_drop_attribution` to correlate with algorithm updates.
+*   **Sitemap errors →** Use `sitemaps_list` to get detailed error info and `sitemaps_submit` to resubmit.
+*   **Anomaly drops →** Use `analytics_time_series` for trend analysis and `inspection_inspect` for de-indexing checks.
+*   **Overall decline →** Use `seo_recommendations` for actionable improvement suggestions.

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "search-console-mcp",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "mcpName": "io.github.saurabhsharma2u/search-console-mcp",
   "description": "MCP server for Google Search Console API",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "search-console-mcp": "./dist/index.js",
-    "search-console-mcp-setup": "./dist/setup.js"
+    "search-console-mcp": "./dist/index.js"
   },
   "files": [
     "dist",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/saurabhsharma2u/search-console-mcp",
     "source": "github"
   },
-  "version": "1.9.2",
+  "version": "1.9.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "search-console-mcp",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/docs/algorithm-updates.ts
+++ b/src/docs/algorithm-updates.ts
@@ -2,18 +2,59 @@
 export const algorithmUpdatesDocs = `
 # Google Algorithm Updates Reference
 
-The \`analytics_drop_attribution\` tool correlates traffic drops with major known Google Algorithm Updates. The following updates are currently supported:
+The \`analytics_drop_attribution\` tool correlates traffic drops with major known Google Algorithm Updates. The following updates are currently tracked (source: [Search Engine Journal](https://www.searchenginejournal.com/google-algorithm-history/)):
+
+## 2026
 
 | Date | Update Name | Impact Area |
 |------|-------------|-------------|
-| 2025-01-15 | January 2025 Core Update | General Ranking |
+| 2026-02-05 | February 2026 Discover Core Update | Discover Feed |
+
+## 2025
+
+| Date | Update Name | Impact Area |
+|------|-------------|-------------|
+| 2025-12-11 | December 2025 Core Update | General Ranking |
+| 2025-08-26 | August 2025 Spam Update | Spam / Content Quality |
+| 2025-06-30 | June 2025 Core Update | General Ranking |
+| 2025-03-13 | March 2025 Core Update | General Ranking |
+
+## 2024
+
+| Date | Update Name | Impact Area |
+|------|-------------|-------------|
+| 2024-12-19 | December 2024 Spam Update | Spam / Content Quality |
+| 2024-12-12 | December 2024 Core Update | General Ranking |
 | 2024-11-11 | November 2024 Core Update | General Ranking |
-| 2024-08-15 | August 2024 Core Update | General Ranking |
+| 2024-08-15 | August 2024 Core Update | General Ranking / Quality |
 | 2024-06-20 | June 2024 Spam Update | Content Quality / Spam |
+| 2024-05-14 | AI Overviews Rollout | Search Features / SERP |
+| 2024-05-06 | Site Reputation Abuse (Manual Actions) | Parasite SEO / Spam |
 | 2024-03-05 | March 2024 Core Update | General Ranking / Quality |
+
+## 2023
+
+| Date | Update Name | Impact Area |
+|------|-------------|-------------|
+| 2023-11-08 | November 2023 Reviews Update | Review Content |
 | 2023-11-02 | November 2023 Core Update | General Ranking |
 | 2023-10-05 | October 2023 Core Update | General Ranking |
+| 2023-10-04 | October 2023 Spam Update | Spam / Multi-language |
 | 2023-09-14 | September 2023 Helpful Content Update | Quality / Value |
+| 2023-08-22 | August 2023 Core Update | General Ranking |
+| 2023-04-12 | April 2023 Reviews Update | Review Content |
+| 2023-03-15 | March 2023 Core Update | General Ranking |
+| 2023-02-21 | February 2023 Product Reviews Update | Product Reviews |
+
+## 2022
+
+| Date | Update Name | Impact Area |
+|------|-------------|-------------|
+| 2022-12-14 | December 2022 Link Spam Update | Link Spam / SpamBrain |
+| 2022-12-05 | December 2022 Helpful Content Update | Quality / Value |
+| 2022-10-19 | October 2022 Spam Update | Spam |
+| 2022-09-20 | September 2022 Product Review Update | Product Reviews |
+| 2022-09-12 | September 2022 Core Update | General Ranking |
 
 ## How Attribution Works
 When a traffic drop is detected, the system checks if it occurred within **+/- 2 days** of any of these dates. If it matches, the update is flagged as a potential primary cause of the drop.

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -178,7 +178,7 @@ export function resolveRepo(dirname: string): string {
     return repo;
 }
 
-async function main() {
+export async function main() {
     printHeader();
 
     console.log('This wizard will help you set up Search Console MCP.');
@@ -264,8 +264,8 @@ async function main() {
 
     // Step 5: Support the project
     printStep(5, 'Support this project');
-    const answer = await ask('Would you like to star the repo on GitHub? (y/n): ');
-    if (answer.toLowerCase().startsWith('y')) {
+    const answer = await ask('Would you like to star the repo on GitHub? (Y/n): ');
+    if (answer === '' || answer.toLowerCase().startsWith('y')) {
         try {
             const repo = resolveRepo(__dirname);
 

--- a/src/tools/advanced-analytics.ts
+++ b/src/tools/advanced-analytics.ts
@@ -26,14 +26,38 @@ export interface DropAttribution {
  * Historical Google Algorithm Update dates (recent notable ones)
  */
 const ALGORITHM_UPDATES = [
+    // 2022
+    { date: '2022-09-12', name: 'September 2022 Core Update' },
+    { date: '2022-09-20', name: 'September 2022 Product Review Update' },
+    { date: '2022-10-19', name: 'October 2022 Spam Update' },
+    { date: '2022-12-05', name: 'December 2022 Helpful Content Update' },
+    { date: '2022-12-14', name: 'December 2022 Link Spam Update' },
+    // 2023
+    { date: '2023-02-21', name: 'February 2023 Product Reviews Update' },
+    { date: '2023-03-15', name: 'March 2023 Core Update' },
+    { date: '2023-04-12', name: 'April 2023 Reviews Update' },
+    { date: '2023-08-22', name: 'August 2023 Core Update' },
     { date: '2023-09-14', name: 'September 2023 Helpful Content Update' },
+    { date: '2023-10-04', name: 'October 2023 Spam Update' },
     { date: '2023-10-05', name: 'October 2023 Core Update' },
     { date: '2023-11-02', name: 'November 2023 Core Update' },
+    { date: '2023-11-08', name: 'November 2023 Reviews Update' },
+    // 2024
     { date: '2024-03-05', name: 'March 2024 Core Update' },
+    { date: '2024-05-06', name: 'Site Reputation Abuse (Manual Actions)' },
+    { date: '2024-05-14', name: 'AI Overviews Rollout' },
     { date: '2024-06-20', name: 'June 2024 Spam Update' },
     { date: '2024-08-15', name: 'August 2024 Core Update' },
     { date: '2024-11-11', name: 'November 2024 Core Update' },
-    { date: '2025-01-15', name: 'January 2025 Core Update' }
+    { date: '2024-12-12', name: 'December 2024 Core Update' },
+    { date: '2024-12-19', name: 'December 2024 Spam Update' },
+    // 2025
+    { date: '2025-03-13', name: 'March 2025 Core Update' },
+    { date: '2025-06-30', name: 'June 2025 Core Update' },
+    { date: '2025-08-26', name: 'August 2025 Spam Update' },
+    { date: '2025-12-11', name: 'December 2025 Core Update' },
+    // 2026
+    { date: '2026-02-05', name: 'February 2026 Discover Core Update' },
 ];
 
 /**

--- a/src/tools/sites-health.ts
+++ b/src/tools/sites-health.ts
@@ -1,0 +1,206 @@
+import * as sites from './sites.js';
+import * as sitemaps from './sitemaps.js';
+import * as analytics from './analytics.js';
+
+/**
+ * Health status for a single site property.
+ */
+export interface SiteHealthReport {
+    /** The site URL. */
+    siteUrl: string;
+    /** Overall status: healthy, warning, or critical. */
+    status: 'healthy' | 'warning' | 'critical';
+    /** Permission level in Search Console. */
+    permissionLevel: string;
+    /** Performance comparison: this week vs last week. */
+    performance: {
+        current: analytics.PerformanceSummary;
+        previous: analytics.PerformanceSummary;
+        changes: {
+            clicks: number;
+            clicksPercent: number;
+            impressions: number;
+            impressionsPercent: number;
+            ctr: number;
+            ctrPercent: number;
+            position: number;
+            positionPercent: number;
+        };
+    };
+    /** Sitemap health summary. */
+    sitemaps: {
+        total: number;
+        withErrors: number;
+        withWarnings: number;
+        details: Array<{
+            path: string;
+            type: string | undefined;
+            isPending: boolean;
+            hasErrors: boolean;
+            lastDownloaded: string | undefined;
+        }>;
+    };
+    /** Detected anomalies in the last 14 days. */
+    anomalies: analytics.AnomalyItem[];
+    /** Human-readable list of issues found. */
+    issues: string[];
+}
+
+/**
+ * Run a health check on a single site, returning a structured report.
+ *
+ * @param siteUrl - The site URL to check.
+ * @returns A health report for the site.
+ */
+async function checkSite(siteUrl: string): Promise<SiteHealthReport> {
+    const issues: string[] = [];
+
+    // Run all checks in parallel
+    const [siteInfo, sitemapList, comparison, anomalies] = await Promise.all([
+        sites.getSite(siteUrl).catch(() => null),
+        sitemaps.listSitemaps(siteUrl).catch(() => []),
+        getWeekOverWeekComparison(siteUrl),
+        analytics.detectAnomalies(siteUrl, { days: 14, threshold: 2.5 }).catch(() => []),
+    ]);
+
+    const permissionLevel = siteInfo?.permissionLevel ?? 'unknown';
+
+    // --- Analyze performance ---
+    const { period1, period2, changes } = comparison;
+
+    if (changes.clicksPercent <= -30) {
+        issues.push(`Critical traffic drop: clicks down ${Math.abs(changes.clicksPercent).toFixed(1)}% week-over-week`);
+    } else if (changes.clicksPercent <= -15) {
+        issues.push(`Traffic declining: clicks down ${Math.abs(changes.clicksPercent).toFixed(1)}% week-over-week`);
+    }
+
+    if (changes.impressionsPercent <= -30) {
+        issues.push(`Critical visibility drop: impressions down ${Math.abs(changes.impressionsPercent).toFixed(1)}% week-over-week`);
+    } else if (changes.impressionsPercent <= -15) {
+        issues.push(`Visibility declining: impressions down ${Math.abs(changes.impressionsPercent).toFixed(1)}% week-over-week`);
+    }
+
+    if (changes.position > 3) {
+        issues.push(`Average position worsened by ${changes.position.toFixed(1)} positions`);
+    }
+
+    if (period1.clicks === 0 && period1.impressions === 0) {
+        issues.push('No traffic data for the current period — site may not be receiving any search traffic');
+    }
+
+    // --- Analyze sitemaps ---
+    let sitemapsWithErrors = 0;
+    let sitemapsWithWarnings = 0;
+    const sitemapDetails = sitemapList.map(sm => {
+        const hasErrors = (Number(sm.errors) || 0) > 0;
+        const isPending = sm.isPending ?? false;
+        if (hasErrors) sitemapsWithErrors++;
+        if ((Number(sm.warnings) || 0) > 0) sitemapsWithWarnings++;
+        return {
+            path: sm.path ?? 'unknown',
+            type: sm.type ?? undefined,
+            isPending,
+            hasErrors,
+            lastDownloaded: sm.lastDownloaded ?? undefined,
+        };
+    });
+
+    if (sitemapList.length === 0) {
+        issues.push('No sitemaps submitted — consider submitting a sitemap for better crawling');
+    }
+    if (sitemapsWithErrors > 0) {
+        issues.push(`${sitemapsWithErrors} sitemap(s) have errors`);
+    }
+    if (sitemapsWithWarnings > 0) {
+        issues.push(`${sitemapsWithWarnings} sitemap(s) have warnings`);
+    }
+
+    // --- Analyze anomalies ---
+    const drops = anomalies.filter(a => a.type === 'drop');
+    if (drops.length > 0) {
+        issues.push(`${drops.length} traffic anomaly drop(s) detected in the last 14 days`);
+    }
+
+    // --- Determine overall status ---
+    let status: SiteHealthReport['status'] = 'healthy';
+    if (issues.some(i => i.startsWith('Critical') || i.includes('No traffic data'))) {
+        status = 'critical';
+    } else if (issues.length > 0) {
+        status = 'warning';
+    }
+
+    return {
+        siteUrl,
+        status,
+        permissionLevel,
+        performance: {
+            current: period1,
+            previous: period2,
+            changes,
+        },
+        sitemaps: {
+            total: sitemapList.length,
+            withErrors: sitemapsWithErrors,
+            withWarnings: sitemapsWithWarnings,
+            details: sitemapDetails,
+        },
+        anomalies,
+        issues,
+    };
+}
+
+/**
+ * Get a week-over-week performance comparison for a site.
+ */
+async function getWeekOverWeekComparison(siteUrl: string): Promise<analytics.PeriodComparison> {
+    const DATA_DELAY_DAYS = 3;
+    const now = new Date();
+
+    const period1End = new Date(now);
+    period1End.setDate(period1End.getDate() - DATA_DELAY_DAYS);
+
+    const period1Start = new Date(period1End);
+    period1Start.setDate(period1Start.getDate() - 7);
+
+    const period2End = new Date(period1Start);
+    period2End.setDate(period2End.getDate() - 1);
+
+    const period2Start = new Date(period2End);
+    period2Start.setDate(period2Start.getDate() - 7);
+
+    const fmt = (d: Date) => d.toISOString().split('T')[0];
+
+    return analytics.comparePeriods(
+        siteUrl,
+        fmt(period1Start),
+        fmt(period1End),
+        fmt(period2Start),
+        fmt(period2End),
+    );
+}
+
+/**
+ * Run a health check on one or all verified sites.
+ *
+ * @param siteUrl - Optional. If provided, check only this site. If omitted, check all verified sites.
+ * @returns An array of health reports.
+ */
+export async function healthCheck(siteUrl?: string): Promise<SiteHealthReport[]> {
+    if (siteUrl) {
+        const report = await checkSite(siteUrl);
+        return [report];
+    }
+
+    const allSites = await sites.listSites();
+    if (allSites.length === 0) {
+        return [];
+    }
+
+    const reports = await Promise.all(
+        allSites.map(site => checkSite(site.siteUrl!))
+    );
+
+    // Sort: critical first, then warning, then healthy
+    const order = { critical: 0, warning: 1, healthy: 2 };
+    return reports.sort((a, b) => order[a.status] - order[b.status]);
+}

--- a/tests/advanced-analytics-v2.test.ts
+++ b/tests/advanced-analytics-v2.test.ts
@@ -45,15 +45,15 @@ describe('Advanced Analytics V2 (Attribution & Time Series)', () => {
         });
 
         it('should detect a known algorithm update', async () => {
-            const rows = Array(20).fill({ keys: ['2025-01-XX'], clicks: 100 });
-            rows.push({ keys: ['2025-01-15'], clicks: 20 }); // Jan 2025 Core Update date
+            const rows = Array(20).fill({ keys: ['2025-03-XX'], clicks: 100 });
+            rows.push({ keys: ['2025-03-13'], clicks: 20 }); // March 2025 Core Update date
 
             mockSearchConsoleClient.searchanalytics.query
                 .mockResolvedValueOnce({ data: { rows } })
                 .mockResolvedValue({ data: { rows: [] } });
 
             const result = await analyzeDropAttribution('https://example.com');
-            expect(result?.possibleAlgorithmUpdate).toBe('January 2025 Core Update');
+            expect(result?.possibleAlgorithmUpdate).toBe('March 2025 Core Update');
         });
     });
 

--- a/tests/sites-health.test.ts
+++ b/tests/sites-health.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockSearchConsoleClient } from './mocks';
+import { healthCheck } from '../src/tools/sites-health';
+
+describe('Sites Health Check', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const makePerfRows = (clicks: number, impressions: number, ctr: number, position: number) => ({
+        data: { rows: [{ clicks, impressions, ctr, position }] }
+    });
+
+    const emptyRows = { data: { rows: [] } };
+
+    it('should return healthy status for a single site with good metrics', async () => {
+        // getSite
+        mockSearchConsoleClient.sites.get.mockResolvedValue({
+            data: { siteUrl: 'https://example.com', permissionLevel: 'siteOwner' }
+        });
+        // listSitemaps
+        mockSearchConsoleClient.sitemaps.list.mockResolvedValue({
+            data: { sitemap: [{ path: 'https://example.com/sitemap.xml', type: 'sitemap', errors: 0, warnings: 0, isPending: false }] }
+        });
+        // comparePeriods: two calls to queryAnalytics (current period then previous)
+        mockSearchConsoleClient.searchanalytics.query
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 8))   // current week
+            .mockResolvedValueOnce(makePerfRows(480, 9800, 0.049, 8.2)) // previous week
+            // detectAnomalies: needs daily data (at least 5 days)
+            .mockResolvedValueOnce({
+                data: {
+                    rows: [
+                        { keys: ['2024-01-01'], clicks: 70, impressions: 1000 },
+                        { keys: ['2024-01-02'], clicks: 72, impressions: 1020 },
+                        { keys: ['2024-01-03'], clicks: 68, impressions: 980 },
+                        { keys: ['2024-01-04'], clicks: 71, impressions: 1010 },
+                        { keys: ['2024-01-05'], clicks: 69, impressions: 990 },
+                    ]
+                }
+            });
+
+        const result = await healthCheck('https://example.com');
+
+        expect(result).toHaveLength(1);
+        expect(result[0].siteUrl).toBe('https://example.com');
+        expect(result[0].status).toBe('healthy');
+        expect(result[0].permissionLevel).toBe('siteOwner');
+        expect(result[0].performance.current.clicks).toBe(500);
+        expect(result[0].performance.previous.clicks).toBe(480);
+        expect(result[0].sitemaps.total).toBe(1);
+        expect(result[0].sitemaps.withErrors).toBe(0);
+        expect(result[0].issues).toHaveLength(0);
+    });
+
+    it('should return warning for moderate traffic decline', async () => {
+        mockSearchConsoleClient.sites.get.mockResolvedValue({
+            data: { siteUrl: 'https://example.com', permissionLevel: 'siteOwner' }
+        });
+        mockSearchConsoleClient.sitemaps.list.mockResolvedValue({
+            data: { sitemap: [{ path: 'https://example.com/sitemap.xml', errors: 0, warnings: 0 }] }
+        });
+        mockSearchConsoleClient.searchanalytics.query
+            .mockResolvedValueOnce(makePerfRows(400, 8000, 0.05, 9))    // current: clicks dropped ~20%
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 8))   // previous
+            .mockResolvedValueOnce({
+                data: {
+                    rows: [
+                        { keys: ['2024-01-01'], clicks: 70 },
+                        { keys: ['2024-01-02'], clicks: 72 },
+                        { keys: ['2024-01-03'], clicks: 68 },
+                        { keys: ['2024-01-04'], clicks: 71 },
+                        { keys: ['2024-01-05'], clicks: 69 },
+                    ]
+                }
+            });
+
+        const result = await healthCheck('https://example.com');
+
+        expect(result[0].status).toBe('warning');
+        expect(result[0].issues.some(i => i.includes('Traffic declining'))).toBe(true);
+    });
+
+    it('should return critical for severe traffic drop', async () => {
+        mockSearchConsoleClient.sites.get.mockResolvedValue({
+            data: { siteUrl: 'https://example.com', permissionLevel: 'siteOwner' }
+        });
+        mockSearchConsoleClient.sitemaps.list.mockResolvedValue({
+            data: { sitemap: [] }
+        });
+        mockSearchConsoleClient.searchanalytics.query
+            .mockResolvedValueOnce(makePerfRows(100, 3000, 0.033, 15))   // current: severe drop
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 8))    // previous
+            .mockResolvedValueOnce({
+                data: {
+                    rows: [
+                        { keys: ['2024-01-01'], clicks: 70 },
+                        { keys: ['2024-01-02'], clicks: 72 },
+                        { keys: ['2024-01-03'], clicks: 68 },
+                        { keys: ['2024-01-04'], clicks: 71 },
+                        { keys: ['2024-01-05'], clicks: 69 },
+                    ]
+                }
+            });
+
+        const result = await healthCheck('https://example.com');
+
+        expect(result[0].status).toBe('critical');
+        expect(result[0].issues.some(i => i.startsWith('Critical traffic drop'))).toBe(true);
+        expect(result[0].issues.some(i => i.startsWith('Critical visibility drop'))).toBe(true);
+        expect(result[0].issues.some(i => i.includes('No sitemaps submitted'))).toBe(true);
+    });
+
+    it('should flag sitemap errors', async () => {
+        mockSearchConsoleClient.sites.get.mockResolvedValue({
+            data: { siteUrl: 'https://example.com', permissionLevel: 'siteOwner' }
+        });
+        mockSearchConsoleClient.sitemaps.list.mockResolvedValue({
+            data: {
+                sitemap: [
+                    { path: 'https://example.com/sitemap.xml', errors: 3, warnings: 1 },
+                ]
+            }
+        });
+        mockSearchConsoleClient.searchanalytics.query
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 8))
+            .mockResolvedValueOnce(makePerfRows(480, 9800, 0.049, 8.2))
+            .mockResolvedValueOnce({
+                data: {
+                    rows: [
+                        { keys: ['2024-01-01'], clicks: 70 },
+                        { keys: ['2024-01-02'], clicks: 72 },
+                        { keys: ['2024-01-03'], clicks: 68 },
+                        { keys: ['2024-01-04'], clicks: 71 },
+                        { keys: ['2024-01-05'], clicks: 69 },
+                    ]
+                }
+            });
+
+        const result = await healthCheck('https://example.com');
+
+        expect(result[0].sitemaps.withErrors).toBe(1);
+        expect(result[0].sitemaps.withWarnings).toBe(1);
+        expect(result[0].issues.some(i => i.includes('sitemap(s) have errors'))).toBe(true);
+        expect(result[0].issues.some(i => i.includes('sitemap(s) have warnings'))).toBe(true);
+    });
+
+    it('should check all sites when no siteUrl is provided', async () => {
+        mockSearchConsoleClient.sites.list.mockResolvedValue({
+            data: {
+                siteEntry: [
+                    { siteUrl: 'https://good.com', permissionLevel: 'siteOwner' },
+                    { siteUrl: 'https://bad.com', permissionLevel: 'siteOwner' },
+                ]
+            }
+        });
+
+        // good.com — healthy
+        mockSearchConsoleClient.sites.get
+            .mockResolvedValueOnce({ data: { siteUrl: 'https://good.com', permissionLevel: 'siteOwner' } })
+            .mockResolvedValueOnce({ data: { siteUrl: 'https://bad.com', permissionLevel: 'siteOwner' } });
+
+        mockSearchConsoleClient.sitemaps.list
+            .mockResolvedValueOnce({ data: { sitemap: [{ path: '/sitemap.xml', errors: 0, warnings: 0 }] } })
+            .mockResolvedValueOnce({ data: { sitemap: [] } });
+
+        mockSearchConsoleClient.searchanalytics.query
+            // good.com: comparePeriods current, previous, anomalies
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 8))
+            .mockResolvedValueOnce(makePerfRows(480, 9800, 0.049, 8.2))
+            .mockResolvedValueOnce({
+                data: {
+                    rows: [
+                        { keys: ['2024-01-01'], clicks: 70 },
+                        { keys: ['2024-01-02'], clicks: 72 },
+                        { keys: ['2024-01-03'], clicks: 68 },
+                        { keys: ['2024-01-04'], clicks: 71 },
+                        { keys: ['2024-01-05'], clicks: 69 },
+                    ]
+                }
+            })
+            // bad.com: severe drop
+            .mockResolvedValueOnce(makePerfRows(50, 1000, 0.05, 20))
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 8))
+            .mockResolvedValueOnce({
+                data: {
+                    rows: [
+                        { keys: ['2024-01-01'], clicks: 70 },
+                        { keys: ['2024-01-02'], clicks: 72 },
+                        { keys: ['2024-01-03'], clicks: 68 },
+                        { keys: ['2024-01-04'], clicks: 71 },
+                        { keys: ['2024-01-05'], clicks: 69 },
+                    ]
+                }
+            });
+
+        const result = await healthCheck();
+
+        expect(result).toHaveLength(2);
+        // Critical should be sorted first
+        expect(result[0].siteUrl).toBe('https://bad.com');
+        expect(result[0].status).toBe('critical');
+        expect(result[1].siteUrl).toBe('https://good.com');
+        expect(result[1].status).toBe('healthy');
+    });
+
+    it('should return empty array when no sites exist', async () => {
+        mockSearchConsoleClient.sites.list.mockResolvedValue({
+            data: { siteEntry: [] }
+        });
+
+        const result = await healthCheck();
+        expect(result).toEqual([]);
+    });
+
+    it('should handle critical when no traffic data at all', async () => {
+        mockSearchConsoleClient.sites.get.mockResolvedValue({
+            data: { siteUrl: 'https://dead.com', permissionLevel: 'siteOwner' }
+        });
+        mockSearchConsoleClient.sitemaps.list.mockResolvedValue({ data: { sitemap: [] } });
+        mockSearchConsoleClient.searchanalytics.query
+            .mockResolvedValueOnce(emptyRows)  // current
+            .mockResolvedValueOnce(emptyRows)  // previous
+            .mockResolvedValueOnce({ data: { rows: [] } }); // anomalies
+
+        const result = await healthCheck('https://dead.com');
+
+        expect(result[0].status).toBe('critical');
+        expect(result[0].issues.some(i => i.includes('No traffic data'))).toBe(true);
+    });
+
+    it('should gracefully handle getSite failure', async () => {
+        mockSearchConsoleClient.sites.get.mockRejectedValue(new Error('Forbidden'));
+        mockSearchConsoleClient.sitemaps.list.mockResolvedValue({
+            data: { sitemap: [{ path: '/sitemap.xml', errors: 0, warnings: 0 }] }
+        });
+        mockSearchConsoleClient.searchanalytics.query
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 8))
+            .mockResolvedValueOnce(makePerfRows(480, 9800, 0.049, 8.2))
+            .mockResolvedValueOnce({
+                data: {
+                    rows: [
+                        { keys: ['2024-01-01'], clicks: 70 },
+                        { keys: ['2024-01-02'], clicks: 72 },
+                        { keys: ['2024-01-03'], clicks: 68 },
+                        { keys: ['2024-01-04'], clicks: 71 },
+                        { keys: ['2024-01-05'], clicks: 69 },
+                    ]
+                }
+            });
+
+        const result = await healthCheck('https://example.com');
+
+        expect(result[0].permissionLevel).toBe('unknown');
+        expect(result[0].status).toBe('healthy');
+    });
+
+    it('should gracefully handle listSitemaps failure', async () => {
+        mockSearchConsoleClient.sites.get.mockResolvedValue({
+            data: { siteUrl: 'https://example.com', permissionLevel: 'siteOwner' }
+        });
+        mockSearchConsoleClient.sitemaps.list.mockRejectedValue(new Error('API error'));
+        mockSearchConsoleClient.searchanalytics.query
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 8))
+            .mockResolvedValueOnce(makePerfRows(480, 9800, 0.049, 8.2))
+            .mockResolvedValueOnce({
+                data: {
+                    rows: [
+                        { keys: ['2024-01-01'], clicks: 70 },
+                        { keys: ['2024-01-02'], clicks: 72 },
+                        { keys: ['2024-01-03'], clicks: 68 },
+                        { keys: ['2024-01-04'], clicks: 71 },
+                        { keys: ['2024-01-05'], clicks: 69 },
+                    ]
+                }
+            });
+
+        const result = await healthCheck('https://example.com');
+
+        // Sitemaps fallback to empty → "No sitemaps submitted" issue
+        expect(result[0].sitemaps.total).toBe(0);
+        expect(result[0].issues.some(i => i.includes('No sitemaps submitted'))).toBe(true);
+    });
+
+    it('should gracefully handle detectAnomalies failure', async () => {
+        mockSearchConsoleClient.sites.get.mockResolvedValue({
+            data: { siteUrl: 'https://example.com', permissionLevel: 'siteOwner' }
+        });
+        mockSearchConsoleClient.sitemaps.list.mockResolvedValue({
+            data: { sitemap: [{ path: '/sitemap.xml', errors: 0, warnings: 0 }] }
+        });
+        mockSearchConsoleClient.searchanalytics.query
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 8))
+            .mockResolvedValueOnce(makePerfRows(480, 9800, 0.049, 8.2))
+            // detectAnomalies call will fail
+            .mockRejectedValueOnce(new Error('Anomaly detection failed'));
+
+        const result = await healthCheck('https://example.com');
+
+        // Anomalies fallback to empty → no anomaly issues
+        expect(result[0].anomalies).toEqual([]);
+        expect(result[0].status).toBe('healthy');
+    });
+
+    it('should flag anomaly drops when detected', async () => {
+        mockSearchConsoleClient.sites.get.mockResolvedValue({
+            data: { siteUrl: 'https://example.com', permissionLevel: 'siteOwner' }
+        });
+        mockSearchConsoleClient.sitemaps.list.mockResolvedValue({
+            data: { sitemap: [{ path: '/sitemap.xml', errors: 0, warnings: 0 }] }
+        });
+        // Create data with a strong anomaly drop on the last day
+        const normalDays = Array.from({ length: 13 }, (_, i) => ({
+            keys: [`2024-01-${String(i + 1).padStart(2, '0')}`],
+            clicks: 100,
+            impressions: 1000,
+        }));
+        const dropDay = {
+            keys: ['2024-01-14'],
+            clicks: 10,  // massive drop — Z-score will trigger
+            impressions: 100,
+        };
+
+        mockSearchConsoleClient.searchanalytics.query
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 8))
+            .mockResolvedValueOnce(makePerfRows(480, 9800, 0.049, 8.2))
+            .mockResolvedValueOnce({ data: { rows: [...normalDays, dropDay] } });
+
+        const result = await healthCheck('https://example.com');
+
+        expect(result[0].anomalies.length).toBeGreaterThan(0);
+        expect(result[0].issues.some(i => i.includes('traffic anomaly drop(s) detected'))).toBe(true);
+        expect(result[0].status).toBe('warning');
+    });
+
+    it('should flag position worsening', async () => {
+        mockSearchConsoleClient.sites.get.mockResolvedValue({
+            data: { siteUrl: 'https://example.com', permissionLevel: 'siteOwner' }
+        });
+        mockSearchConsoleClient.sitemaps.list.mockResolvedValue({
+            data: { sitemap: [{ path: '/sitemap.xml', errors: 0, warnings: 0 }] }
+        });
+        mockSearchConsoleClient.searchanalytics.query
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 15))  // current: position 15
+            .mockResolvedValueOnce(makePerfRows(500, 10000, 0.05, 8))   // previous: position 8 — delta = 7
+            .mockResolvedValueOnce({
+                data: {
+                    rows: [
+                        { keys: ['2024-01-01'], clicks: 70 },
+                        { keys: ['2024-01-02'], clicks: 72 },
+                        { keys: ['2024-01-03'], clicks: 68 },
+                        { keys: ['2024-01-04'], clicks: 71 },
+                        { keys: ['2024-01-05'], clicks: 69 },
+                    ]
+                }
+            });
+
+        const result = await healthCheck('https://example.com');
+
+        expect(result[0].issues.some(i => i.includes('Average position worsened'))).toBe(true);
+        expect(result[0].status).toBe('warning');
+    });
+});
+


### PR DESCRIPTION
## What's New

### 🩺 `sites_health_check` Tool
A new tool that runs automated health diagnostics on one or all verified Search Console properties.

**Checks performed (in parallel per site):**
- **Week-over-week performance** — clicks, impressions, CTR, position changes
- **Sitemap status** — errors, warnings, missing sitemaps
- **Traffic anomalies** — statistical drop detection (Z-score, 14-day window)

**Output:** Structured report per site with `healthy` / `warning` / `critical` status, sorted with critical sites first.

**Parameters:**
| Param | Required | Description |
|-------|----------|-------------|
| `siteUrl` | No | Check a single site, or omit to check all |

### 📊 Algorithm Updates Refresh
- Expanded from **8 → 27 entries** covering 2022–2026
- Sourced from [Search Engine Journal](https://www.searchenginejournal.com/google-algorithm-history/)
- Includes all 2025/2026 updates (March, June, Aug, Dec 2025 + Feb 2026 Discover)

### 🔧 Setup Command Simplification
- Simplified to: `npx -y search-console-mcp setup`
- Removed stale `search-console-mcp-setup` bin entry from `package.json`
- Star repo prompt now defaults to yes

### 📖 Documentation
- New `docs/tools/site-health.md` — comprehensive tool documentation
- New `site-health-check` MCP prompt registered in server
- Updated all prompt docs (Claude, Cursor, Generic) with health check examples
- Updated getting-started docs (overview, first-queries)

### ✅ Tests
- **12 new tests** for `sites-health.ts` with **100% statement/line/function coverage**
- Updated algorithm update test to use real March 2025 Core Update
- Total: **93 tests, all passing**

### Version
Bumped to **1.9.3**