### PR TITLE
⚡ Optimize schema validation by hoisting Validator instantiation

### DIFF
--- a/src/tools/schema-validator.ts
+++ b/src/tools/schema-validator.ts
@@ -55,8 +55,8 @@ export async function validateSchema(
             return { valid: false, errors: ["No structured data (JSON-LD) found"], schemas: [] };
         }
 
+        const validator = new Validator();
         const validationPromises = schemas.map(async (schema) => {
-            const validator = new Validator();
             try {
                 const result = await validator.validate(schema);
                 if (result && Array.isArray(result) && result.length > 0) {


### PR DESCRIPTION
💡 **What:**
- Hoisted `const validator = new Validator();` outside of the `schemas.map(...)` loop in `src/tools/schema-validator.ts`.
- This ensures that a single `Validator` instance is reused for all schema validations within a single request, instead of creating a new instance for each schema.

🎯 **Why:**
- Instantiating `Validator` inside the loop is inefficient, especially when processing multiple schemas (e.g., from a page with many JSON-LD blocks).
- Reusing the instance reduces memory allocation and initialization overhead.

📊 **Measured Improvement:**
- **Baseline:** ~2.44ms (avg for 100 schemas)
- **Optimized:** ~2.60ms (avg for 100 schemas)
- **Result:** The performance difference is negligible (within noise margin) because `Validator` instantiation is extremely lightweight (~0.0055ms).
- **Correctness Note:** During verification, I discovered that `validator.validate(schema)` currently returns an empty array (success) for all inputs because the library expects a specific input format (WAE data object) but receives a raw schema object. This means the validator is currently a no-op in the production code. My change preserves this behavior while optimizing the instantiation step.
- **Thread Safety:** Verified that `Validator` is stateless and safe for concurrent use (even if the input format were corrected).

---
*PR created automatically by Jules for task [17808201141553328884](https://jules.google.com/task/17808201141553328884) started by @saurabhsharma2u*