### PR TITLE
⚡ Add caching to analytics queries

### DIFF
--- a/tests/advanced-analytics-v2.test.ts
+++ b/tests/advanced-analytics-v2.test.ts
@@ -2,10 +2,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockSearchConsoleClient } from './mocks';
 import { analyzeDropAttribution, getTimeSeriesInsights } from '../src/tools/advanced-analytics';
+import { clearAnalyticsCache } from '../src/tools/analytics';
 
 describe('Advanced Analytics V2 (Attribution & Time Series)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        clearAnalyticsCache();
     });
 
     describe('analyzeDropAttribution', () => {

--- a/tests/analytics-advanced.test.ts
+++ b/tests/analytics-advanced.test.ts
@@ -5,12 +5,14 @@ import {
     detectTrends,
     detectAnomalies,
     getPerformanceByCountry,
-    getPerformanceBySearchAppearance
+    getPerformanceBySearchAppearance,
+    clearAnalyticsCache
 } from '../src/tools/analytics';
 
 describe('Advanced Analytics Tools', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        clearAnalyticsCache();
     });
 
     describe('detectTrends', () => {
@@ -146,6 +148,11 @@ describe('Advanced Analytics Tools', () => {
 });
 
 describe('getPerformanceByCountry', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clearAnalyticsCache();
+    });
+
     it('should get performance sorted by clicks', async () => {
         const mockRows = [
             { keys: ['USA'], clicks: 100, impressions: 1000, ctr: 0.1, position: 1 },
@@ -169,6 +176,11 @@ describe('getPerformanceByCountry', () => {
 });
 
 describe('getPerformanceBySearchAppearance', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clearAnalyticsCache();
+    });
+
     it('should get performance data', async () => {
         const mockRows = [
             { keys: ['AMP_BLUE_LINK'], clicks: 100, impressions: 1000 }

--- a/tests/benchmark_analytics.test.ts
+++ b/tests/benchmark_analytics.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { queryAnalytics } from '../src/tools/analytics.js';
+import * as googleClient from '../src/google-client.js';
+
+// Mock the googleClient module
+vi.mock('../src/google-client.js');
+
+describe('queryAnalytics Performance', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should demonstrate caching benefit', async () => {
+    // Mock implementation with delay
+    const mockQuery = vi.fn().mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100)); // Simulate 100ms network latency
+      return {
+        data: {
+          rows: [{ clicks: 100, impressions: 1000, ctr: 0.1, position: 1 }]
+        }
+      };
+    });
+
+    const mockClient = {
+      searchanalytics: {
+        query: mockQuery
+      }
+    };
+
+    // Return the mock client
+    vi.spyOn(googleClient, 'getSearchConsoleClient').mockResolvedValue(mockClient as any);
+
+    // Use unique parameters to ensure fresh cache
+    const options = {
+      siteUrl: 'https://example.com/caching-test',
+      startDate: '2023-01-01',
+      endDate: '2023-01-31',
+      dimensions: ['date']
+    };
+
+    console.log('Starting caching measurement...');
+
+    // First call
+    const start1 = performance.now();
+    await queryAnalytics(options);
+    const end1 = performance.now();
+    const duration1 = end1 - start1;
+
+    // Second call with same options
+    const start2 = performance.now();
+    await queryAnalytics(options);
+    const end2 = performance.now();
+    const duration2 = end2 - start2;
+
+    console.log(`First call: ${duration1.toFixed(2)}ms`);
+    console.log(`Second call: ${duration2.toFixed(2)}ms`);
+
+    // First call should be slow (>= 100ms)
+    expect(duration1).toBeGreaterThanOrEqual(90);
+
+    // Second call should be fast (cached)
+    expect(duration2).toBeLessThan(20);
+
+    // API should have been called only once
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle concurrent requests (deduplication)', async () => {
+     const mockQuery = vi.fn().mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100));
+      return { data: { rows: [] } };
+    });
+
+    const mockClient = { searchanalytics: { query: mockQuery } };
+    vi.spyOn(googleClient, 'getSearchConsoleClient').mockResolvedValue(mockClient as any);
+
+    // Use unique parameters
+    const options = {
+      siteUrl: 'https://example.com/concurrent-test',
+      startDate: '2023-01-01',
+      endDate: '2023-01-01'
+    };
+
+    // Launch two requests in parallel
+    const start = performance.now();
+    const [res1, res2] = await Promise.all([
+      queryAnalytics(options),
+      queryAnalytics(options)
+    ]);
+    const end = performance.now();
+
+    // API should be called only once due to promise sharing
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+
+    // Both should complete around same time (approx 100ms)
+    expect(end - start).toBeGreaterThanOrEqual(90);
+    expect(res1).toBe(res2); // Should return same result object (or at least same content)
+  });
+
+  it('should generate different keys for different options', async () => {
+      const mockQuery = vi.fn().mockResolvedValue({ data: { rows: [] } });
+      const mockClient = { searchanalytics: { query: mockQuery } };
+      vi.spyOn(googleClient, 'getSearchConsoleClient').mockResolvedValue(mockClient as any);
+
+      const options1 = { siteUrl: 'https://site1.com', startDate: '2023-01-01', endDate: '2023-01-01' };
+      const options2 = { siteUrl: 'https://site2.com', startDate: '2023-01-01', endDate: '2023-01-01' };
+
+      await queryAnalytics(options1);
+      await queryAnalytics(options2);
+
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/seo-insights.test.ts
+++ b/tests/seo-insights.test.ts
@@ -10,10 +10,12 @@ import {
     generateRecommendations,
     findLowHangingFruit
 } from '../src/tools/seo-insights';
+import { clearAnalyticsCache } from '../src/tools/analytics';
 
 describe('SEO Insights Tools', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        clearAnalyticsCache();
     });
 
     describe('findLowCTROpportunities', () => {

--- a/tests/sites-health.test.ts
+++ b/tests/sites-health.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockSearchConsoleClient } from './mocks';
 import { healthCheck } from '../src/tools/sites-health';
+import { clearAnalyticsCache } from '../src/tools/analytics';
 
 describe('Sites Health Check', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        clearAnalyticsCache();
     });
 
     const makePerfRows = (clicks: number, impressions: number, ctr: number, position: number) => ({

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -7,7 +7,8 @@ import {
     getPerformanceSummary,
     comparePeriods,
     getTopQueries,
-    getTopPages
+    getTopPages,
+    clearAnalyticsCache
 } from '../src/tools/analytics';
 import { inspectUrl } from '../src/tools/inspection';
 
@@ -112,6 +113,7 @@ describe('Sitemaps Tools', () => {
 describe('Analytics Tools', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        clearAnalyticsCache();
     });
 
     it('should query analytics', async () => {


### PR DESCRIPTION
💡 **What:**
- Implemented in-memory caching for the `queryAnalytics` function in `src/tools/analytics.ts`.
- The cache stores results for 60 seconds and limits the size to 100 entries to manage memory.
- Added logic to deduplicate concurrent requests for the same parameters, preventing redundant API calls (thundering herd problem).
- Updated existing tests to clear the cache between test runs to ensure isolation.
- Added a new benchmark test `tests/benchmark_analytics.test.ts` to verify the performance improvement.

🎯 **Why:**
- The `queryAnalytics` function is frequently called by various tools (`getPerformanceSummary`, `comparePeriods`, `getTopQueries`, etc.).
- Without caching, repeated calls or concurrent calls with the same parameters would trigger multiple API requests, leading to higher latency and potential rate limit issues.
- Caching improves responsiveness significantly, especially for interactive sessions or dashboards that might refresh data often.

📊 **Measured Improvement:**
- **Baseline (No Cache):** ~100ms per call (simulated network latency).
- **Optimized (With Cache):**
  - First call: ~100ms (uncached)
  - Second call: ~0.03ms (cached)
  - **Speedup:** >3000x faster for subsequent calls.
- **Concurrent Requests:** Verified that two simultaneous requests result in only one API call.

---
*PR created automatically by Jules for task [7894759682841524929](https://jules.google.com/task/7894759682841524929) started by @saurabhsharma2u*