### PR TITLE
fix: Correct LICENSE link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,5 +158,5 @@ These are low-level tools designed to be used by other AI agents to build comple
 
 ## License
 
-[MIT](LICENSE.md)
+[MIT](LICENSE)
 [Contributing](CONTRIBUTING.md)


### PR DESCRIPTION
The README.md incorrectly linked to `[MIT](LICENSE.md)`, but the file is named `LICENSE` (without .md extension). This fixes the broken link.

Fixes #20