### PR TITLE
Fix schema validator invocation format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "search-console-mcp",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search-console-mcp",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@adobe/structured-data-validator": "^1.6.0",

--- a/src/common/tools/schema-validator.ts
+++ b/src/common/tools/schema-validator.ts
@@ -58,7 +58,17 @@ export async function validateSchema(
         const validator = new Validator();
         const validationPromises = schemas.map(async (schema) => {
             try {
-                const result = await validator.validate(schema);
+                let type = schema['@type'];
+                if (Array.isArray(type)) {
+                    type = type[0];
+                }
+                const wrapper = {
+                    jsonld: {
+                        [type || 'Thing']: [schema]
+                    }
+                };
+                const result = await validator.validate(wrapper);
+
                 if (result && Array.isArray(result) && result.length > 0) {
                     // result is array of errors
                     return result.map((err: any) => ({

--- a/tests/schema-validator.test.ts
+++ b/tests/schema-validator.test.ts
@@ -6,16 +6,28 @@ import { validateSchema } from '../src/common/tools/schema-validator';
 vi.mock('@adobe/structured-data-validator', () => {
     return {
         default: class Validator {
-            async validate(schema: any) {
-                if (schema.shouldThrow) {
-                    throw new Error('Mock error');
+            async validate(input: any) {
+                let schemas: any[] = [];
+                if (input.jsonld) {
+                    for (const key of Object.keys(input.jsonld)) {
+                        schemas.push(...input.jsonld[key]);
+                    }
+                } else {
+                    schemas = [input];
                 }
-                if (schema.shouldFail) {
-                    return [{ message: 'Validation failed', type: 'error' }];
+
+                for (const schema of schemas) {
+                    if (schema.shouldThrow) {
+                        throw new Error('Mock error');
+                    }
+                    if (schema.shouldFail) {
+                        return [{ message: 'Validation failed', type: 'error' }];
+                    }
                 }
+
                 // Simulate delay
                 await new Promise(resolve => setTimeout(resolve, 10));
-                return { valid: true };
+                return [];
             }
         }
     };


### PR DESCRIPTION
Fixes a bug where `validateSchema` was returning valid results for invalid schemas because the input format was incorrect for the underlying library.

---
*PR created automatically by Jules for task [2147090481440180457](https://jules.google.com/task/2147090481440180457) started by @saurabhsharma2u*