### PR TITLE
⚡ Optimize Google Health Check: Remove redundant N+1 site lookups

### DIFF
--- a/src/google/tools/sites-health.ts
+++ b/src/google/tools/sites-health.ts
@@ -51,14 +51,15 @@ export interface SiteHealthReport {
  * Run a health check on a single site, returning a structured report.
  *
  * @param siteUrl - The site URL to check.
+ * @param existingSiteInfo - Optional. Pre-fetched site info to avoid redundant calls.
  * @returns A health report for the site.
  */
-async function checkSite(siteUrl: string): Promise<SiteHealthReport> {
+async function checkSite(siteUrl: string, existingSiteInfo?: Awaited<ReturnType<typeof sites.getSite>>): Promise<SiteHealthReport> {
     const issues: string[] = [];
 
     // Run all checks in parallel
     const [siteInfo, sitemapList, comparison, anomalies] = await Promise.all([
-        sites.getSite(siteUrl).catch(() => null),
+        existingSiteInfo ? Promise.resolve(existingSiteInfo) : sites.getSite(siteUrl).catch(() => null),
         sitemaps.listSitemaps(siteUrl).catch(() => []),
         getWeekOverWeekComparison(siteUrl),
         analytics.detectAnomalies(siteUrl, { days: 14, threshold: 2.5 }).catch(() => []),
@@ -197,7 +198,7 @@ export async function healthCheck(siteUrl?: string): Promise<SiteHealthReport[]>
         return [];
     }
 
-    const reports = await limitConcurrency(allSites, 5, site => checkSite(site.siteUrl!));
+    const reports = await limitConcurrency(allSites, 5, site => checkSite(site.siteUrl!, site));
 
     // Sort: critical first, then warning, then healthy
     const order = { critical: 0, warning: 1, healthy: 2 };

--- a/tests/benchmark_sites_health_opt.test.ts
+++ b/tests/benchmark_sites_health_opt.test.ts
@@ -1,0 +1,53 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockSearchConsoleClient } from './mocks';
+import { healthCheck } from '../src/google/tools/sites-health';
+import { clearAnalyticsCache } from '../src/google/tools/analytics';
+
+describe('Sites Health Check Benchmark', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clearAnalyticsCache();
+    });
+
+    const makePerfRows = (clicks: number, impressions: number, ctr: number, position: number) => ({
+        data: { rows: [{ clicks, impressions, ctr, position }] }
+    });
+
+    it('should count calls to sites.get', async () => {
+        const siteCount = 10;
+        const sites = Array.from({ length: siteCount }, (_, i) => ({
+            siteUrl: `https://site${i}.com`,
+            permissionLevel: 'siteOwner'
+        }));
+
+        mockSearchConsoleClient.sites.list.mockResolvedValue({
+            data: { siteEntry: sites }
+        });
+
+        // Mock getSite for each site
+        mockSearchConsoleClient.sites.get.mockImplementation(({ siteUrl }) => {
+            return Promise.resolve({
+                data: { siteUrl, permissionLevel: 'siteOwner' }
+            });
+        });
+
+        // Mock other calls to be fast
+        mockSearchConsoleClient.sitemaps.list.mockResolvedValue({
+            data: { sitemap: [] }
+        });
+        mockSearchConsoleClient.searchanalytics.query
+            .mockResolvedValue(makePerfRows(100, 1000, 0.1, 5));
+
+        const start = performance.now();
+        await healthCheck();
+        const end = performance.now();
+
+        console.log(`Execution time: ${(end - start).toFixed(2)}ms`);
+        console.log(`sites.get calls: ${mockSearchConsoleClient.sites.get.mock.calls.length}`);
+
+        // In the optimized version, we pass the site info directly, so getSite is not called.
+        // So we expect 0 calls.
+        expect(mockSearchConsoleClient.sites.get).toHaveBeenCalledTimes(0);
+    });
+});

--- a/tests/sites-health.test.ts
+++ b/tests/sites-health.test.ts
@@ -157,9 +157,7 @@ describe('Sites Health Check', () => {
         });
 
         // good.com — healthy
-        mockSearchConsoleClient.sites.get
-            .mockResolvedValueOnce({ data: { siteUrl: 'https://good.com', permissionLevel: 'siteOwner' } })
-            .mockResolvedValueOnce({ data: { siteUrl: 'https://bad.com', permissionLevel: 'siteOwner' } });
+        // Note: sites.get is no longer called during iteration because site info is passed directly
 
         mockSearchConsoleClient.sitemaps.list
             .mockResolvedValueOnce({ data: { sitemap: [{ path: '/sitemap.xml', errors: 0, warnings: 0 }] } })


### PR DESCRIPTION
Modified `checkSite` to accept optional `siteInfo` to avoid redundant `getSite` calls when iterating over sites in `healthCheck`.
Added a benchmark test `tests/benchmark_sites_health_opt.test.ts` which confirms `sites.get` calls dropped from N (10) to 0.
Updated `tests/sites-health.test.ts` to remove unused mocks for `sites.get` in iteration tests.

---
*PR created automatically by Jules for task [14535522519534029965](https://jules.google.com/task/14535522519534029965) started by @saurabhsharma2u*