### PR TITLE
⚡ Optimize SEO Insights API Calls

### DIFF
--- a/src/google/tools/seo-insights.ts
+++ b/src/google/tools/seo-insights.ts
@@ -1,6 +1,7 @@
 import { queryAnalytics } from './analytics.js';
 import { safeTestBatch } from '../../common/utils/regex.js';
 
+type AnalyticsRows = Awaited<ReturnType<typeof queryAnalytics>>;
 
 /**
  * Insight: A single SEO recommendation or finding
@@ -178,6 +179,29 @@ export interface BrandVsNonBrandMetrics {
     queryCount: number;
 }
 
+function aggregateQueryPageToQuery(rows: AnalyticsRows): AnalyticsRows {
+    const map = new Map<string, { clicks: number; impressions: number; position: number; ctr: number }>();
+    for (const row of rows) {
+        const query = row.keys?.[0] || '';
+        if (!map.has(query)) {
+            map.set(query, { clicks: 0, impressions: 0, position: 0, ctr: 0 });
+        }
+        const entry = map.get(query)!;
+        entry.clicks += row.clicks || 0;
+        entry.impressions += row.impressions || 0;
+        // Weighted position sum
+        entry.position += (row.position || 0) * (row.impressions || 0);
+    }
+
+    return Array.from(map.entries()).map(([query, stats]) => ({
+        keys: [query],
+        clicks: stats.clicks,
+        impressions: stats.impressions,
+        ctr: stats.impressions ? stats.clicks / stats.impressions : 0,
+        position: stats.impressions ? stats.position / stats.impressions : 0
+    }));
+}
+
 /**
  * Find "low-hanging fruit" keywords: high impressions, low CTR, and positions in striking distance.
  *
@@ -187,25 +211,32 @@ export interface BrandVsNonBrandMetrics {
  */
 export async function findLowHangingFruit(
     siteUrl: string,
-    options: { days?: number; minImpressions?: number; limit?: number } = {}
+    options: { days?: number; minImpressions?: number; limit?: number } = {},
+    rows?: AnalyticsRows
 ): Promise<LowHangingFruit[]> {
     const { days = 28, minImpressions = 100, limit = 50 } = options;
 
-    const endDate = new Date();
-    endDate.setDate(endDate.getDate() - 3); // Account for GSC data delay
-    const startDate = new Date(endDate);
-    startDate.setDate(startDate.getDate() - days);
+    let analyticsRows: AnalyticsRows;
 
-    const rows = await queryAnalytics({
-        siteUrl,
-        startDate: startDate.toISOString().split('T')[0],
-        endDate: endDate.toISOString().split('T')[0],
-        dimensions: ['query'],
-        limit: 5000
-    });
+    if (rows) {
+        analyticsRows = aggregateQueryPageToQuery(rows);
+    } else {
+        const endDate = new Date();
+        endDate.setDate(endDate.getDate() - 3); // Account for GSC data delay
+        const startDate = new Date(endDate);
+        startDate.setDate(startDate.getDate() - days);
+
+        analyticsRows = await queryAnalytics({
+            siteUrl,
+            startDate: startDate.toISOString().split('T')[0],
+            endDate: endDate.toISOString().split('T')[0],
+            dimensions: ['query'],
+            limit: 5000
+        });
+    }
 
     // Filter for low-hanging fruit: position 5-20, high impressions, low CTR
-    const candidates = rows
+    const candidates = analyticsRows
         .filter(row => {
             const position = row.position ?? 100;
             const impressions = row.impressions ?? 0;
@@ -245,22 +276,29 @@ export async function findLowHangingFruit(
  */
 export async function detectCannibalization(
     siteUrl: string,
-    options: { days?: number; minImpressions?: number; limit?: number } = {}
+    options: { days?: number; minImpressions?: number; limit?: number } = {},
+    rows?: AnalyticsRows
 ): Promise<CannibalizationIssue[]> {
     const { days = 28, minImpressions = 50, limit = 30 } = options;
 
-    const endDate = new Date();
-    endDate.setDate(endDate.getDate() - 3);
-    const startDate = new Date(endDate);
-    startDate.setDate(startDate.getDate() - days);
+    let analyticsRows: AnalyticsRows;
 
-    const rows = await queryAnalytics({
-        siteUrl,
-        startDate: startDate.toISOString().split('T')[0],
-        endDate: endDate.toISOString().split('T')[0],
-        dimensions: ['query', 'page'],
-        limit: 10000
-    });
+    if (rows) {
+        analyticsRows = rows;
+    } else {
+        const endDate = new Date();
+        endDate.setDate(endDate.getDate() - 3);
+        const startDate = new Date(endDate);
+        startDate.setDate(startDate.getDate() - days);
+
+        analyticsRows = await queryAnalytics({
+            siteUrl,
+            startDate: startDate.toISOString().split('T')[0],
+            endDate: endDate.toISOString().split('T')[0],
+            dimensions: ['query', 'page'],
+            limit: 10000
+        });
+    }
 
     // Group by query
     const queryMap = new Map<string, Array<{
@@ -271,7 +309,7 @@ export async function detectCannibalization(
         ctr: number;
     }>>();
 
-    for (const row of rows) {
+    for (const row of analyticsRows) {
         const query = row.keys?.[0] ?? '';
         const page = row.keys?.[1] ?? '';
         const impressions = row.impressions ?? 0;
@@ -566,25 +604,34 @@ export async function analyzeBrandVsNonBrand(
  */
 export async function findQuickWins(
     siteUrl: string,
-    options: { days?: number; minImpressions?: number; limit?: number } = {}
+    options: { days?: number; minImpressions?: number; limit?: number } = {},
+    rows?: AnalyticsRows,
+    keyOrder: 'queryFirst' | 'pageFirst' = 'pageFirst'
 ): Promise<QuickWin[]> {
     const { days = 28, minImpressions = 100, limit = 20 } = options;
 
-    const endDate = new Date();
-    endDate.setDate(endDate.getDate() - 3);
-    const startDate = new Date(endDate);
-    startDate.setDate(startDate.getDate() - days);
+    let analyticsRows: AnalyticsRows;
 
-    const rows = await queryAnalytics({
-        siteUrl,
-        startDate: startDate.toISOString().split('T')[0],
-        endDate: endDate.toISOString().split('T')[0],
-        dimensions: ['page', 'query'],
-        limit: 10000
-    });
+    if (rows) {
+        analyticsRows = rows;
+    } else {
+        const endDate = new Date();
+        endDate.setDate(endDate.getDate() - 3);
+        const startDate = new Date(endDate);
+        startDate.setDate(startDate.getDate() - days);
+
+        analyticsRows = await queryAnalytics({
+            siteUrl,
+            startDate: startDate.toISOString().split('T')[0],
+            endDate: endDate.toISOString().split('T')[0],
+            dimensions: ['page', 'query'],
+            limit: 10000
+        });
+        keyOrder = 'pageFirst';
+    }
 
     // Simplified logic: Just find page+query pairs in positions 11-20
-    const quickWins: QuickWin[] = rows
+    const quickWins: QuickWin[] = analyticsRows
         .map(r => {
             const impressions = r.impressions ?? 0;
             const clicks = r.clicks ?? 0;
@@ -592,9 +639,12 @@ export async function findQuickWins(
             // Estimate potential clicks if moved to top 3 (conservative 15% CTR)
             const potentialClicks = Math.round(impressions * 0.15) - clicks;
 
+            const page = keyOrder === 'pageFirst' ? (r.keys?.[0] ?? '') : (r.keys?.[1] ?? '');
+            const query = keyOrder === 'pageFirst' ? (r.keys?.[1] ?? '') : (r.keys?.[0] ?? '');
+
             return {
-                page: r.keys?.[0] ?? '',
-                query: r.keys?.[1] ?? '',
+                page,
+                query,
                 position: r.position ?? 0,
                 impressions,
                 potentialClicks: Math.max(0, potentialClicks)
@@ -621,11 +671,25 @@ export async function generateRecommendations(
     const { days = 28 } = options;
     const insights: SEOInsight[] = [];
 
-    // Run all analysis tasks in parallel
+    // Fetch superset of data once
+    const endDate = new Date();
+    endDate.setDate(endDate.getDate() - 3);
+    const startDate = new Date(endDate);
+    startDate.setDate(startDate.getDate() - days);
+
+    const analyticsRows = await queryAnalytics({
+        siteUrl,
+        startDate: startDate.toISOString().split('T')[0],
+        endDate: endDate.toISOString().split('T')[0],
+        dimensions: ['query', 'page'],
+        limit: 10000
+    });
+
+    // Run analysis tasks using the shared data
     const [lowHangingFruit, cannibalization, quickWins] = await Promise.all([
-        findLowHangingFruit(siteUrl, { days, limit: 10 }),
-        detectCannibalization(siteUrl, { days, limit: 10 }),
-        findQuickWins(siteUrl, { days, limit: 10 })
+        findLowHangingFruit(siteUrl, { days, limit: 10 }, analyticsRows),
+        detectCannibalization(siteUrl, { days, limit: 10 }, analyticsRows),
+        findQuickWins(siteUrl, { days, limit: 10 }, analyticsRows, 'queryFirst')
     ]);
 
     // Process low-hanging fruit

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -1,5 +1,35 @@
 import { vi } from 'vitest';
 
+vi.mock('re2', () => {
+  return {
+    default: class RE2 {
+      private regex: RegExp;
+      constructor(pattern: string, flags?: string) {
+        this.regex = new RegExp(pattern, flags);
+      }
+      match(str: string) { return this.regex.exec(str); }
+      test(str: string) { return this.regex.test(str); }
+    }
+  };
+});
+
+vi.mock('googleapis', () => {
+  return {
+      google: {
+          auth: {
+              GoogleAuth: class {},
+              OAuth2: class {}
+          },
+          searchconsole: () => ({
+              searchanalytics: {
+                  query: vi.fn()
+              }
+          })
+      },
+      searchconsole_v1: {}
+  };
+});
+
 export const mockSearchConsoleClient = {
   sites: {
     list: vi.fn(),

--- a/tests/seo-insights.test.ts
+++ b/tests/seo-insights.test.ts
@@ -169,20 +169,17 @@ describe('SEO Insights Tools', () => {
 
     describe('generateRecommendations', () => {
         it('should generate a list of insights', async () => {
-            // Mock responses for all internal calls
-            mockSearchConsoleClient.searchanalytics.query
-                // 1. findLowHangingFruit
-                .mockResolvedValueOnce({
-                    data: { rows: [{ keys: ['fruit', 'p1'], position: 6, impressions: 2000, clicks: 100 }] }
-                })
-                // 2. detectCannibalization
-                .mockResolvedValueOnce({
-                    data: { rows: [] } // No cannibalization
-                })
-                // 3. findQuickWins
-                .mockResolvedValueOnce({
-                    data: { rows: [{ keys: ['page2', 'win'], position: 12, impressions: 1000, clicks: 50 }] }
-                });
+            // Mock response for the single call
+            mockSearchConsoleClient.searchanalytics.query.mockResolvedValueOnce({
+                data: {
+                    rows: [
+                        // lowHangingFruit
+                        { keys: ['fruit', 'p1'], position: 6, impressions: 2000, clicks: 100 },
+                        // quickWins (page2, win) - Note: keys are [query, page] because of generateRecommendations request
+                        { keys: ['win', 'page2'], position: 12, impressions: 1000, clicks: 50 }
+                    ]
+                }
+            });
 
             const result = await generateRecommendations('https://example.com');
 
@@ -191,25 +188,22 @@ describe('SEO Insights Tools', () => {
             expect(opportunities.length).toBeGreaterThan(0);
             expect(result[0].priority).toBeDefined();
         });
-    });
 
-    it('should report cannibalization issues', async () => {
-        mockSearchConsoleClient.searchanalytics.query
-            .mockResolvedValueOnce({ data: { rows: [] } }) // lowHangingFruit
-            .mockResolvedValueOnce({
+        it('should report cannibalization issues', async () => {
+            mockSearchConsoleClient.searchanalytics.query.mockResolvedValueOnce({
                 data: {
                     rows: [
                         { keys: ['conflict', 'p1'], position: 5, impressions: 1000, clicks: 50 },
                         { keys: ['conflict', 'p2'], position: 6, impressions: 1000, clicks: 50 }
                     ]
                 }
-            }) // detectCannibalization
-            .mockResolvedValueOnce({ data: { rows: [] } }); // findQuickWins
+            });
 
-        const result = await generateRecommendations('https://example.com');
-        const warning = result.find(i => i.type === 'warning');
-        expect(warning).toBeDefined();
-        expect(warning?.title).toContain('cannibalization issues');
+            const result = await generateRecommendations('https://example.com');
+            const warning = result.find(i => i.type === 'warning');
+            expect(warning).toBeDefined();
+            expect(warning?.title).toContain('cannibalization issues');
+        });
     });
 });
 


### PR DESCRIPTION
Optimized `generateRecommendations` in `src/google/tools/seo-insights.ts` to fetch a superset of data (`['query', 'page']`) once and pass it to `findLowHangingFruit`, `detectCannibalization`, and `findQuickWins`. This reduces API calls from 3 to 1 (~66% reduction).

Added `aggregateQueryPageToQuery` helper to aggregate `['query', 'page']` data into `['query']` format for `findLowHangingFruit`.
Updated `findQuickWins` to handle `['query', 'page']` data (swapped key order) when provided.
Updated `tests/seo-insights.test.ts` to reflect the single API call and updated `tests/mocks.ts` to mock `re2` and `googleapis` for test execution in the environment.

---
*PR created automatically by Jules for task [1801978806071331845](https://jules.google.com/task/1801978806071331845) started by @saurabhsharma2u*