### PR TITLE
Add CSV export to analytics tools and improve Bing query

### DIFF
--- a/src/common/utils/csv.ts
+++ b/src/common/utils/csv.ts
@@ -1,0 +1,34 @@
+/**
+ * Convert an array of flat JSON objects to a CSV string.
+ * Automatically handles escaping of double quotes and commas.
+ */
+export function jsonToCsv(data: Record<string, any>[]): string {
+  if (!data || data.length === 0) {
+    return "";
+  }
+
+  // Get headers from the first object
+  const headers = Object.keys(data[0]);
+
+  const csvRows = [headers.join(',')];
+
+  for (const row of data) {
+    const values = headers.map(header => {
+      const val = row[header];
+      const stringVal = val === undefined || val === null ? '' : String(val);
+
+      // Escape double quotes by doubling them
+      const escaped = stringVal.replace(/"/g, '""');
+
+      // Wrap in quotes if it contains comma, quote or newline
+      if (escaped.includes(',') || escaped.includes('"') || escaped.includes('\n')) {
+        return `"${escaped}"`;
+      }
+
+      return escaped;
+    });
+    csvRows.push(values.join(','));
+  }
+
+  return csvRows.join('\n');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { getStartedHandler, getStartedToolName, getStartedToolDescription, getStartedToolSchema } from "./common/tools/get-started.js";
 import { registerPrompts } from "./prompts/index.js";
+import { jsonToCsv } from "./common/utils/csv.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -299,11 +300,32 @@ server.tool(
       dimension: z.string(),
       operator: z.string(),
       expression: z.string()
-    })).optional().describe("Filters (dimension: query/page/country/device, operator: equals/contains/notContains/includingRegex/excludingRegex)")
+    })).optional().describe("Filters (dimension: query/page/country/device, operator: equals/contains/notContains/includingRegex/excludingRegex)"),
+    format: z.enum(["json", "csv"]).optional().describe("Output format (default: json)")
   },
   async (args) => {
     try {
       const result = await analytics.queryAnalytics(args);
+
+      if (args.format === 'csv') {
+        const flatData = result.map(row => {
+          const newRow: any = { ...row };
+          if (row.keys && Array.isArray(row.keys)) {
+            row.keys.forEach((keyVal, idx) => {
+              const dimName = args.dimensions && args.dimensions[idx]
+                ? args.dimensions[idx]
+                : `dimension_${idx + 1}`;
+              newRow[dimName] = keyVal;
+            });
+            delete newRow.keys;
+          }
+          return newRow;
+        });
+        return {
+          content: [{ type: "text", text: jsonToCsv(flatData) }]
+        };
+      }
+
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };
@@ -1123,11 +1145,26 @@ server.tool(
   "bing_analytics_query",
   "Get query performance stats from Bing Webmaster Tools (Top Queries)",
   {
-    siteUrl: z.string().describe("The URL of the site")
+    siteUrl: z.string().describe("The URL of the site"),
+    startDate: z.string().optional().describe("Start date (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("End date (YYYY-MM-DD)"),
+    limit: z.number().optional().describe("Max rows to return (default: 1000)"),
+    format: z.enum(["json", "csv"]).optional().describe("Output format (default: json)")
   },
-  async ({ siteUrl }) => {
+  async ({ siteUrl, startDate, endDate, limit, format }) => {
     try {
-      const results = await bingAnalytics.getQueryStats(siteUrl);
+      let results = await bingAnalytics.getQueryStats(siteUrl, startDate, endDate);
+
+      if (limit) {
+        results = results.slice(0, limit);
+      }
+
+      if (format === 'csv') {
+        return {
+          content: [{ type: "text", text: jsonToCsv(results) }]
+        };
+      }
+
       return {
         content: [{ type: "text", text: JSON.stringify(results, null, 2) }]
       };
@@ -1629,11 +1666,17 @@ server.tool(
     startDate: z.string().describe("Start date (YYYY-MM-DD)"),
     endDate: z.string().describe("End date (YYYY-MM-DD)"),
     pagePath: z.string().optional().describe("Filter by specific page path"),
-    limit: z.number().optional().describe("Max rows (default 50)")
+    limit: z.number().optional().describe("Max rows (default 50)"),
+    format: z.enum(["json", "csv"]).optional().describe("Output format (default: json)")
   },
-  async ({ propertyId, accountId, startDate, endDate, pagePath, limit }) => {
+  async ({ propertyId, accountId, startDate, endDate, pagePath, limit, format }) => {
     try {
       const result = await ga4Analytics.getPagePerformance(propertyId, startDate, endDate, pagePath, limit, accountId);
+      if (format === 'csv') {
+        return {
+          content: [{ type: "text", text: jsonToCsv(result) }]
+        };
+      }
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { jsonToCsv } from '../src/common/utils/csv.js';
+
+describe('jsonToCsv', () => {
+    it('returns empty string for empty input', () => {
+        expect(jsonToCsv([])).toBe('');
+    });
+
+    it('handles simple flat objects', () => {
+        const data = [
+            { id: 1, name: 'Alice' },
+            { id: 2, name: 'Bob' }
+        ];
+        const expected = "id,name\n1,Alice\n2,Bob";
+        expect(jsonToCsv(data)).toBe(expected);
+    });
+
+    it('handles missing values', () => {
+        const data = [
+            { id: 1, name: 'Alice' },
+            { id: 2, name: null }
+        ];
+        // Note: Object keys order is not guaranteed in JS, but usually consistent for insertion order.
+        // Assuming 'id', 'name' order.
+        // If keys order is different, we can adjust the test.
+        // However, usually V8 preserves insertion order for string keys.
+
+        // Let's ensure consistent order by defining keys explicitly if needed, but jsonToCsv uses Object.keys(data[0]).
+        // If data[0] has id then name, it uses that order.
+
+        const result = jsonToCsv(data);
+        const expected = "id,name\n1,Alice\n2,";
+        expect(result).toBe(expected);
+    });
+
+    it('handles special characters (commas, quotes, newlines)', () => {
+        const data = [
+            { id: 1, text: 'Hello, world' },
+            { id: 2, text: 'She said "Hi"' },
+            { id: 3, text: 'Line 1\nLine 2' }
+        ];
+        const result = jsonToCsv(data);
+        const expected = `id,text
+1,"Hello, world"
+2,"She said ""Hi"""
+3,"Line 1\nLine 2"`;
+        expect(result).toBe(expected);
+    });
+
+    it('handles undefined values', () => {
+        const data = [
+            { a: 1, b: undefined },
+            { a: 2, b: 3 }
+        ];
+        // If first row has undefined value, it still has the key if explicitly set to undefined.
+        // But if key is missing, Object.keys won't pick it up.
+        // If data[0] has keys 'a' and 'b', then headers are 'a','b'.
+
+        const result = jsonToCsv(data);
+        const expected = "a,b\n1,\n2,3";
+        expect(result).toBe(expected);
+    });
+});


### PR DESCRIPTION
This PR introduces CSV export capabilities for the main analytics tools, fulfilling the roadmap item for "Export Capabilities". 

It adds a `format` parameter (default: 'json') to `analytics_query`, `bing_analytics_query`, and `analytics_page_performance`. When set to 'csv', the tools return the data as a CSV formatted string.

Additionally, `bing_analytics_query` was updated to accept `startDate`, `endDate`, and `limit` parameters, leveraging the existing logic in `src/bing/tools/analytics.ts`.

A new utility `jsonToCsv` was added with unit tests covering various edge cases like quoting and escaping.

---
*PR created automatically by Jules for task [11668002615428203847](https://jules.google.com/task/11668002615428203847) started by @saurabhsharma2u*