### PR TITLE
Add compatibility CLI dispatcher with shared legacy command routing

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -23,3 +23,80 @@ CLI adapters and routing are organized around these modules:
 - Google OAuth client module: `src/google/client.ts`
 - Auth account config persistence: `src/common/auth/config.ts`
 - Auth account resolution helpers: `src/common/auth/resolver.ts`
+
+## Adapter-first execution plan
+
+Roadmap execution for CLI work should always start by adapting existing MCP/tool modules before introducing new business logic.
+
+1. Inventory existing tool modules first (Google, Bing, GA4, and shared common tools).
+2. For each planned CLI command, map command handling to an existing module/function.
+3. Only add new core logic when no equivalent tool exists; place shared reusable logic in `src/common` so both MCP tools and CLI adapters consume the same implementation.
+4. Keep the tracking matrix below updated as commands are planned or implemented.
+
+## Tool module inventory
+
+### `src/google/tools`
+
+- `advanced-analytics.ts`
+- `analytics.ts`
+- `inspection.ts`
+- `pagespeed.ts`
+- `seo-insights.ts`
+- `sitemaps.ts`
+- `sites-health.ts`
+- `sites.ts`
+- `support.ts`
+
+### `src/bing/tools`
+
+- `advanced-analytics.ts`
+- `analytics.ts`
+- `crawl.ts`
+- `index-now.ts`
+- `inspection.ts`
+- `keywords.ts`
+- `links.ts`
+- `seo-insights.ts`
+- `sitemaps.ts`
+- `sites-health.ts`
+- `sites.ts`
+- `url-submission.ts`
+
+### `src/ga4/tools`
+
+- `analytics.ts`
+- `behavior.ts`
+- `pagespeed.ts`
+- `properties.ts`
+- `realtime.ts`
+
+### `src/common/tools`
+
+- `compare-engines/adapters.ts`
+- `compare-engines/comparator.ts`
+- `compare-engines/ga4-adapters.ts`
+- `compare-engines/ga4-gsc-bing-comparator.ts`
+- `compare-engines/ga4-gsc-comparator.ts`
+- `compare-engines/index.ts`
+- `compare-engines/normalizer.ts`
+- `compare-engines/signals.ts`
+- `compare-engines/types.ts`
+- `compare-engines/utils.ts`
+- `get-started.ts`
+- `schema-validator.ts`
+- `seo-primitives.ts`
+
+## CLI adapter tracking matrix
+
+| CLI command | backing module | new logic required (Y/N) |
+| --- | --- | --- |
+| `setup` | `src/setup.ts#main` (via `src/cli/adapters.ts`) | N |
+| `login` | `src/setup.ts#login` (via `src/cli/adapters.ts`) | N |
+| `logout` | `src/setup.ts#runLogout` (via `src/cli/adapters.ts`) | N |
+| `accounts` / `account` | `src/accounts.ts#main` (via `src/cli/adapters.ts`) | N |
+| `sites` | `src/accounts.ts#main(['list'])` (via `src/cli/adapters.ts`) | N |
+| `auth` | `src/auth.ts#main` (via `src/cli/adapters.ts`) | N |
+| `diagnostics` | `src/common/diagnostics.ts#runDiagnostics` (via `src/cli/adapters.ts`) | N |
+| `analytics query` (planned) | `src/google/tools/analytics.ts#queryAnalytics` via `src/cli/commands/analytics.ts#getAnalyticsQueryRawRecords` | N |
+| `bing analytics query` (planned) | `src/bing/tools/analytics.ts#getQueryStats` via `src/cli/commands/analytics.ts#getBingAnalyticsQueryRawRecords` | N |
+| `ga4 page-performance` (planned) | `src/ga4/tools/analytics.ts#getPagePerformance` via `src/cli/commands/analytics.ts#getGa4PagePerformanceRawRecords` | N |

--- a/CLI.md
+++ b/CLI.md
@@ -1,0 +1,25 @@
+# CLI Architecture Notes
+
+This document captures canonical implementation module paths used by the CLI entrypoints and adapters.
+
+## Canonical implementation references
+
+- Google API client/auth helpers: `src/google/client.ts`
+- Interactive setup/login flow: `src/setup.ts`
+- Shared auth persistence + resolution: `src/common/auth/config.ts`, `src/common/auth/resolver.ts`
+
+When describing or extending CLI auth behavior, reference the modules above (not legacy flattened paths).
+
+## Code map
+
+CLI adapters and routing are organized around these modules:
+
+- CLI binary entrypoint: `cli/index.ts`
+- Legacy adapter factory: `src/cli/adapters.ts`
+- Legacy command router: `src/cli/router.ts`
+- Setup/login/logout command implementation: `src/setup.ts`
+- Account and sites command implementation: `src/accounts.ts`
+- Auth subcommand implementation: `src/auth.ts`
+- Google OAuth client module: `src/google/client.ts`
+- Auth account config persistence: `src/common/auth/config.ts`
+- Auth account resolution helpers: `src/common/auth/resolver.ts`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -160,6 +160,13 @@ This document outlines the planned features and improvements for this project.
 - **Enhanced Bing Analytics**:
   - Added `startDate`, `endDate`, and `limit` parameters to `bing_analytics_query`.
 
+### v1.13.5 - Auth CLI Hardening
+
+- **Auth CLI Commands**:
+  - `auth status` - Reports account state from encrypted config (`~/.search-console-mcp-config.enc`) and existing env/legacy fallbacks
+  - `auth revoke` - Revokes account access via existing token/account cleanup flows (Google keychain cleanup + account removal)
+- **Security Wording Updates**: Documentation now consistently references encrypted config storage and keychain-backed token handling.
+
 ---
 
 ## 🚧 In Progress

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -173,6 +173,11 @@ This document outlines the planned features and improvements for this project.
 
 - **Performance Optimizations**: Further reducing API footprint across all insight modules.
 - **Enhanced Documentation**: Mintlify-driven user guides and cross-platform strategies. SEO upgrade (title, description, keywords)
+- **CLI Adapter-First Execution**:
+  - Inventory tool modules in `src/google/tools`, `src/bing/tools`, `src/ga4/tools`, and `src/common/tools` before scheduling CLI feature work.
+  - Map each planned CLI command to an existing tool function/module first.
+  - Only add new core logic when no existing tool equivalence is available; shared logic must live in `src/common` for MCP/CLI reuse.
+  - Maintain `CLI.md` tracking matrix (`CLI command`, `backing module`, `new logic required (Y/N)`) as the source of truth for command implementation readiness.
 
 ---
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2,14 +2,18 @@
 import 'dotenv/config';
 import { createLegacyCommandAdapters } from '../src/cli/adapters.js';
 import { routeLegacyCommand } from '../src/cli/router.js';
+import { applyGlobalFlags, parseGlobalFlags } from '../src/cli/global-flags.js';
 
 function printHelp(): void {
-  console.log(`Search Console CLI\n\nUsage:\n  search-console-cli <command> [options]\n\nLegacy commands:\n  setup\n  accounts\n  account\n  login\n  logout\n  auth\n  diagnostics\n  sites`);
+  console.log(`Search Console CLI\n\nUsage:\n  search-console-mcp <command> [options]\n\nLegacy commands:\n  setup\n  accounts\n  account\n  login\n  logout\n  auth\n  diagnostics\n  sites
+  config`);
 }
 
 async function main() {
-  const command = process.argv[2];
-  const handled = await routeLegacyCommand(command, process.argv.slice(3), await createLegacyCommandAdapters());
+  const parsed = parseGlobalFlags(process.argv.slice(2));
+  const argv = applyGlobalFlags(parsed);
+  const command = argv[0];
+  const handled = await routeLegacyCommand(command, argv.slice(1), await createLegacyCommandAdapters());
 
   if (handled) {
     return;

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -4,7 +4,7 @@ import { createLegacyCommandAdapters } from '../src/cli/adapters.js';
 import { routeLegacyCommand } from '../src/cli/router.js';
 
 function printHelp(): void {
-  console.log(`Search Console CLI\n\nUsage:\n  search-console-cli <command> [options]\n\nLegacy commands:\n  setup\n  accounts\n  account\n  login\n  logout\n  diagnostics\n  sites`);
+  console.log(`Search Console CLI\n\nUsage:\n  search-console-cli <command> [options]\n\nLegacy commands:\n  setup\n  accounts\n  account\n  login\n  logout\n  auth\n  diagnostics\n  sites`);
 }
 
 async function main() {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { createLegacyCommandAdapters } from '../src/cli/adapters.js';
+import { routeLegacyCommand } from '../src/cli/router.js';
+
+function printHelp(): void {
+  console.log(`Search Console CLI\n\nUsage:\n  search-console-cli <command> [options]\n\nLegacy commands:\n  setup\n  accounts\n  account\n  login\n  logout\n  diagnostics\n  sites`);
+}
+
+async function main() {
+  const command = process.argv[2];
+  const handled = await routeLegacyCommand(command, process.argv.slice(3), await createLegacyCommandAdapters());
+
+  if (handled) {
+    return;
+  }
+
+  printHelp();
+  process.exitCode = command ? 1 : 0;
+}
+
+main().catch((error) => {
+  console.error('Fatal error in CLI dispatcher:', error);
+  process.exit(1);
+});

--- a/docs/cli-compatibility-design.md
+++ b/docs/cli-compatibility-design.md
@@ -1,0 +1,23 @@
+# CLI Compatibility Design
+
+## Goals
+- Preserve `src/index.ts` as the MCP stdio bootstrap path for existing integrations.
+- Introduce a separate human-facing CLI entrypoint in `cli/index.ts`.
+- Reuse the same command adapters for legacy operational commands (`setup`, `accounts`, `login`, `logout`, `diagnostics`, `sites`) to avoid behavior drift.
+
+## Routing Strategy
+1. **Shared adapters** live in `src/cli/adapters.ts` and encapsulate command execution.
+2. **Shared router** in `src/cli/router.ts` resolves command strings to adapters.
+3. `src/index.ts` invokes the shared router first; if no legacy command is matched, it proceeds to start MCP transport on stdio.
+4. `cli/index.ts` invokes the same shared router and otherwise shows CLI help.
+
+## Bin Compatibility
+- Keep existing `search-console-mcp` bin mapped to MCP bootstrap semantics.
+- Add a second bin (`search-console-cli`) mapped to the new CLI dispatcher.
+- Add a secondary TypeScript build config (`tsconfig.cli.json`) so `cli/index.ts` compiles into `dist/cli/index.js` without changing the existing main build layout.
+
+## Regression Coverage
+Add `tests/cli-routing.test.ts` to validate:
+- no subcommand means MCP mode should continue (`shouldStartMcp(undefined)` is true),
+- each legacy command is routed through adapters successfully,
+- unknown commands are not consumed by legacy routing.

--- a/docs/cli-compatibility-design.md
+++ b/docs/cli-compatibility-design.md
@@ -11,6 +11,12 @@
 3. `src/index.ts` invokes the shared router first; if no legacy command is matched, it proceeds to start MCP transport on stdio.
 4. `cli/index.ts` invokes the same shared router and otherwise shows CLI help.
 
+
+## CLI Auth Implementation References
+- Interactive auth/login flows are implemented in `src/setup.ts` (`setup`, `login`, `logout`).
+- Account persistence and account resolution are implemented in `src/common/auth/config.ts` and `src/common/auth/resolver.ts`.
+- OAuth client helpers are implemented in `src/google/client.ts`.
+
 ## Bin Compatibility
 - Keep existing `search-console-mcp` bin mapped to MCP bootstrap semantics.
 - Add a second bin (`search-console-cli`) mapped to the new CLI dispatcher.

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -29,13 +29,23 @@ npx search-console-mcp setup
 
 ### Logout & Management
 
-You can manage your sessions directly from the CLI:
+You can inspect and revoke sessions directly from the CLI (state is read from encrypted config at `~/.search-console-mcp-config.enc`, with keychain-backed OAuth token handling):
 
 ```bash
-# Logout of the default account
-npx search-console-mcp logout
+# Show current auth status (includes legacy/env fallbacks when present)
+npx search-console-mcp auth status
 
-# Logout of a specific account by email
+# Revoke one account (cleans keychain tokens for Google OAuth accounts)
+npx search-console-mcp auth revoke --account=user@gmail.com
+
+# Revoke all configured accounts
+npx search-console-mcp auth revoke --all
+```
+
+Legacy compatibility commands still work:
+
+```bash
+npx search-console-mcp logout
 npx search-console-mcp logout user@gmail.com
 ```
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "test": "vitest run",
     "docs": "typedoc",
     "deploy:registry": "mcp-publisher publish",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "lint": "tsc --noEmit && tsc -p tsconfig.cli.json --noEmit",
+    "test:cli": "vitest run tests/cli-routing.test.ts tests/auth-cli.test.ts tests/cli-output-format.test.ts tests/global-flags.test.ts"
   },
   "keywords": [
     "mcp",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "search-console-mcp": "./dist/index.js"
+    "search-console-mcp": "./dist/index.js",
+    "search-console-cli": "./dist/cli/index.js"
   },
   "files": [
     "dist",
@@ -14,7 +15,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.cli.json",
     "test": "vitest run",
     "docs": "typedoc",
     "deploy:registry": "mcp-publisher publish",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,137 @@
+import { loadConfig, removeAccount } from './common/auth/config.js';
+import { logout } from './google/client.js';
+
+function parseFlags(args: string[]): Record<string, string | boolean> {
+  const flags: Record<string, string | boolean> = {};
+  for (const arg of args) {
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+
+    const [rawKey, value] = arg.slice(2).split('=');
+    if (!rawKey) {
+      continue;
+    }
+
+    flags[rawKey] = value ?? true;
+  }
+  return flags;
+}
+
+function findAccount(accounts: Record<string, any>, identifier: string) {
+  if (accounts[identifier]) {
+    return accounts[identifier];
+  }
+
+  return Object.values(accounts).find(
+    (account: any) => account.alias?.toLowerCase() === identifier.toLowerCase() || account.id === identifier
+  );
+}
+
+async function authStatus() {
+  const config = await loadConfig();
+  const accounts = Object.values(config.accounts);
+
+  const response = {
+    accounts: accounts.map((account: any) => ({
+      id: account.id,
+      alias: account.alias,
+      engine: account.engine,
+      websites: account.websites || [],
+      legacy: !!account.isLegacy,
+      hasServiceAccountPath: !!account.serviceAccountPath,
+      hasApiKey: !!account.apiKey,
+      hasTokens: !!account.tokens?.refresh_token || !!account.tokens?.access_token
+    })),
+    summary: {
+      total: accounts.length,
+      google: accounts.filter((a) => a.engine === 'google').length,
+      bing: accounts.filter((a) => a.engine === 'bing').length,
+      ga4: accounts.filter((a) => a.engine === 'ga4').length
+    },
+    storage: {
+      config: '~/.search-console-mcp-config.enc',
+      tokens: 'OS keychain (fallback: encrypted account config)'
+    }
+  };
+
+  console.log(JSON.stringify(response, null, 2));
+}
+
+async function authRevoke(args: string[]) {
+  const flags = parseFlags(args);
+  const positional = args.filter((arg) => !arg.startsWith('--'));
+  const identifier = (flags.account as string) || (flags.id as string) || positional[0];
+  const revokeAll = !!flags.all;
+
+  const config = await loadConfig();
+  const allAccounts = Object.values(config.accounts) as any[];
+
+  let accountsToRevoke: any[] = [];
+  if (revokeAll) {
+    accountsToRevoke = allAccounts;
+  } else if (identifier) {
+    const account = findAccount(config.accounts, identifier);
+    if (!account) {
+      console.log(JSON.stringify({
+        error: 'Account not found',
+        message: `No account matching '${identifier}' was found.`,
+        resolution: 'Run: search-console-mcp auth status'
+      }, null, 2));
+      return;
+    }
+    accountsToRevoke = [account];
+  } else {
+    console.log(JSON.stringify({
+      error: 'Missing arguments',
+      message: 'Provide --account=<alias|id> to revoke a single account, or --all to revoke every account.',
+      resolution: {
+        single: 'search-console-mcp auth revoke --account=<alias_or_id>',
+        all: 'search-console-mcp auth revoke --all'
+      }
+    }, null, 2));
+    return;
+  }
+
+  for (const account of accountsToRevoke) {
+    if (account.engine === 'google') {
+      await logout(account.id);
+      continue;
+    }
+
+    await removeAccount(account.id);
+  }
+
+  console.log(JSON.stringify({
+    success: true,
+    revoked: accountsToRevoke.map((account) => ({
+      id: account.id,
+      alias: account.alias,
+      engine: account.engine
+    }))
+  }, null, 2));
+}
+
+export async function main(args: string[]) {
+  const subcommand = args[0] || 'status';
+
+  if (subcommand === 'status') {
+    await authStatus();
+    return;
+  }
+
+  if (subcommand === 'revoke') {
+    await authRevoke(args.slice(1));
+    return;
+  }
+
+  console.log(JSON.stringify({
+    error: 'Unknown auth command',
+    message: `'${subcommand}' is not a valid auth subcommand.`,
+    resolution: {
+      status: 'search-console-mcp auth status',
+      revoke: 'search-console-mcp auth revoke --account=<alias_or_id>',
+      revoke_all: 'search-console-mcp auth revoke --all'
+    }
+  }, null, 2));
+}

--- a/src/cli/adapters.ts
+++ b/src/cli/adapters.ts
@@ -1,0 +1,41 @@
+import { runDiagnostics } from "../common/diagnostics.js";
+
+export type LegacyCommand = 'setup' | 'account' | 'accounts' | 'logout' | 'login' | 'diagnostics' | 'sites';
+
+export interface LegacyCommandAdapters {
+  setup: () => Promise<void>;
+  accounts: (args: string[]) => Promise<void>;
+  logout: () => Promise<void>;
+  login: () => Promise<void>;
+  diagnostics: () => Promise<void>;
+  sites: () => Promise<void>;
+}
+
+export async function createLegacyCommandAdapters(): Promise<LegacyCommandAdapters> {
+  return {
+    setup: async () => {
+      const { main } = await import('../setup.js');
+      await main();
+    },
+    accounts: async (args: string[]) => {
+      const { main } = await import('../accounts.js');
+      await main(args);
+    },
+    logout: async () => {
+      const { runLogout } = await import('../setup.js');
+      await runLogout();
+    },
+    login: async () => {
+      const { login } = await import('../setup.js');
+      await login();
+    },
+    diagnostics: async () => {
+      const results = await runDiagnostics();
+      console.log(JSON.stringify(results, null, 2));
+    },
+    sites: async () => {
+      const { main } = await import('../accounts.js');
+      await main(['list']);
+    }
+  };
+}

--- a/src/cli/adapters.ts
+++ b/src/cli/adapters.ts
@@ -1,6 +1,6 @@
 import { runDiagnostics } from "../common/diagnostics.js";
 
-export type LegacyCommand = 'setup' | 'account' | 'accounts' | 'logout' | 'login' | 'auth' | 'diagnostics' | 'sites';
+export type LegacyCommand = 'setup' | 'account' | 'accounts' | 'logout' | 'login' | 'auth' | 'diagnostics' | 'sites' | 'config';
 
 export interface LegacyCommandAdapters {
   setup: () => Promise<void>;
@@ -10,6 +10,7 @@ export interface LegacyCommandAdapters {
   auth: (args: string[]) => Promise<void>;
   diagnostics: () => Promise<void>;
   sites: () => Promise<void>;
+  config: (args: string[]) => Promise<void>;
 }
 
 export async function createLegacyCommandAdapters(): Promise<LegacyCommandAdapters> {
@@ -41,6 +42,10 @@ export async function createLegacyCommandAdapters(): Promise<LegacyCommandAdapte
     sites: async () => {
       const { main } = await import('../accounts.js');
       await main(['list']);
+    },
+    config: async (args: string[]) => {
+      const { main } = await import('./config.js');
+      await main(args);
     }
   };
 }

--- a/src/cli/adapters.ts
+++ b/src/cli/adapters.ts
@@ -1,12 +1,13 @@
 import { runDiagnostics } from "../common/diagnostics.js";
 
-export type LegacyCommand = 'setup' | 'account' | 'accounts' | 'logout' | 'login' | 'diagnostics' | 'sites';
+export type LegacyCommand = 'setup' | 'account' | 'accounts' | 'logout' | 'login' | 'auth' | 'diagnostics' | 'sites';
 
 export interface LegacyCommandAdapters {
   setup: () => Promise<void>;
   accounts: (args: string[]) => Promise<void>;
   logout: () => Promise<void>;
   login: () => Promise<void>;
+  auth: (args: string[]) => Promise<void>;
   diagnostics: () => Promise<void>;
   sites: () => Promise<void>;
 }
@@ -28,6 +29,10 @@ export async function createLegacyCommandAdapters(): Promise<LegacyCommandAdapte
     login: async () => {
       const { login } = await import('../setup.js');
       await login();
+    },
+    auth: async (args: string[]) => {
+      const { main } = await import('../auth.js');
+      await main(args);
     },
     diagnostics: async () => {
       const results = await runDiagnostics();

--- a/src/cli/commands/analytics.ts
+++ b/src/cli/commands/analytics.ts
@@ -1,0 +1,90 @@
+import * as analytics from "../../google/tools/analytics.js";
+import * as bingAnalytics from "../../bing/tools/analytics.js";
+import * as ga4Analytics from "../../ga4/tools/analytics.js";
+import { formatRecords, OutputMode, RawRecord } from "../output/formatter.js";
+
+export interface AnalyticsQueryRawArgs {
+  siteUrl: string;
+  startDate: string;
+  endDate: string;
+  dimensions?: string[];
+  type?: "web" | "image" | "video" | "news" | "discover" | "googleNews";
+  aggregationType?: "auto" | "byProperty" | "byPage";
+  dataState?: "final" | "all";
+  limit?: number;
+  startRow?: number;
+  filters?: Array<{ dimension: string; operator: string; expression: string }>;
+}
+
+export type AnalyticsQueryRecord = RawRecord;
+
+export async function getAnalyticsQueryRawRecords(args: AnalyticsQueryRawArgs): Promise<AnalyticsQueryRecord[]> {
+  const result = await analytics.queryAnalytics(args);
+
+  return result.map((row) => {
+    const newRow: Record<string, unknown> = { ...row };
+    if (row.keys && Array.isArray(row.keys)) {
+      row.keys.forEach((keyVal, idx) => {
+        const dimName = args.dimensions && args.dimensions[idx]
+          ? args.dimensions[idx]
+          : `dimension_${idx + 1}`;
+        newRow[dimName] = keyVal;
+      });
+      delete newRow.keys;
+    }
+    return newRow;
+  });
+}
+
+export interface BingAnalyticsQueryRawArgs {
+  siteUrl: string;
+  startDate?: string;
+  endDate?: string;
+  limit?: number;
+}
+
+export async function getBingAnalyticsQueryRawRecords(args: BingAnalyticsQueryRawArgs): Promise<RawRecord[]> {
+  let results = await bingAnalytics.getQueryStats(args.siteUrl, args.startDate, args.endDate);
+  if (args.limit) {
+    results = results.slice(0, args.limit);
+  }
+  return results.map((row) => ({ ...row })) as RawRecord[];
+}
+
+export interface Ga4PagePerformanceRawArgs {
+  propertyId: string;
+  accountId?: string;
+  startDate: string;
+  endDate: string;
+  pagePath?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function getGa4PagePerformanceRawRecords(args: Ga4PagePerformanceRawArgs): Promise<RawRecord[]> {
+  const result = await ga4Analytics.getPagePerformance(
+    args.propertyId,
+    args.startDate,
+    args.endDate,
+    args.pagePath,
+    args.limit,
+    args.accountId,
+    args.offset
+  );
+  return result.map((row: Record<string, unknown>) => ({ ...row })) as RawRecord[];
+}
+
+export async function runAnalyticsQueryCli(args: AnalyticsQueryRawArgs, mode: OutputMode): Promise<string> {
+  const records = await getAnalyticsQueryRawRecords(args);
+  return formatRecords(records, mode);
+}
+
+export async function runBingAnalyticsQueryCli(args: BingAnalyticsQueryRawArgs, mode: OutputMode): Promise<string> {
+  const records = await getBingAnalyticsQueryRawRecords(args);
+  return formatRecords(records, mode);
+}
+
+export async function runGa4PagePerformanceCli(args: Ga4PagePerformanceRawArgs, mode: OutputMode): Promise<string> {
+  const records = await getGa4PagePerformanceRawRecords(args);
+  return formatRecords(records, mode);
+}

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,0 +1,142 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+const GLOBAL_CONFIG_DIR = join(homedir(), '.search-console-mcp');
+const GLOBAL_CONFIG_PATH = join(GLOBAL_CONFIG_DIR, 'config.json');
+const PROJECT_CONFIG_PATH = '.search-console-mcp.json';
+
+function readConfig(path: string): Record<string, unknown> {
+  if (!existsSync(path)) {
+    return {};
+  }
+
+  const raw = readFileSync(path, 'utf8');
+  if (!raw.trim()) {
+    return {};
+  }
+
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+function writeConfig(path: string, config: Record<string, unknown>): void {
+  if (path === GLOBAL_CONFIG_PATH && !existsSync(GLOBAL_CONFIG_DIR)) {
+    mkdirSync(GLOBAL_CONFIG_DIR, { recursive: true, mode: 0o700 });
+  }
+
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+}
+
+function setByPath(target: Record<string, unknown>, key: string, value: unknown): void {
+  const parts = key.split('.').filter(Boolean);
+  if (parts.length === 0) {
+    return;
+  }
+
+  let cursor: Record<string, unknown> = target;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const part = parts[i];
+    const child = cursor[part];
+
+    if (!child || typeof child !== 'object' || Array.isArray(child)) {
+      cursor[part] = {};
+    }
+
+    cursor = cursor[part] as Record<string, unknown>;
+  }
+
+  cursor[parts[parts.length - 1]] = value;
+}
+
+function getByPath(target: Record<string, unknown>, key: string): unknown {
+  const parts = key.split('.').filter(Boolean);
+  let cursor: unknown = target;
+
+  for (const part of parts) {
+    if (!cursor || typeof cursor !== 'object' || Array.isArray(cursor) || !(part in cursor)) {
+      return undefined;
+    }
+
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+
+  return cursor;
+}
+
+function parseValue(raw: string): unknown {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  if (raw === 'null') return null;
+
+  const asNumber = Number(raw);
+  if (!Number.isNaN(asNumber) && raw.trim() !== '') {
+    return asNumber;
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function parseScope(args: string[]) {
+  const isProject = args.includes('--project');
+  const filtered = args.filter((arg) => arg !== '--project' && arg !== '--global');
+  return {
+    path: isProject ? PROJECT_CONFIG_PATH : GLOBAL_CONFIG_PATH,
+    scope: isProject ? 'project' : 'global',
+    args: filtered
+  };
+}
+
+export async function main(args: string[]): Promise<void> {
+  const [subcommand, ...rest] = args;
+  const { path, scope, args: scopedArgs } = parseScope(rest);
+
+  if (subcommand === 'set') {
+    const [key, ...valueParts] = scopedArgs;
+    const rawValue = valueParts.join(' ').trim();
+
+    if (!key || rawValue.length === 0) {
+      console.log(JSON.stringify({
+        error: 'Missing arguments',
+        usage: 'search-console-mcp config set <key> <value> [--project|--global]'
+      }, null, 2));
+      return;
+    }
+
+    const config = readConfig(path);
+    setByPath(config, key, parseValue(rawValue));
+    writeConfig(path, config);
+
+    console.log(JSON.stringify({ success: true, scope, path, key, value: getByPath(config, key) }, null, 2));
+    return;
+  }
+
+  if (subcommand === 'get') {
+    const [key] = scopedArgs;
+    if (!key) {
+      console.log(JSON.stringify({
+        error: 'Missing arguments',
+        usage: 'search-console-mcp config get <key> [--project|--global]'
+      }, null, 2));
+      return;
+    }
+
+    const config = readConfig(path);
+    const value = getByPath(config, key);
+
+    console.log(JSON.stringify({ scope, path, key, value }, null, 2));
+    return;
+  }
+
+  console.log(JSON.stringify({
+    error: 'Unknown config command',
+    supported: ['set', 'get'],
+    usage: {
+      set: 'search-console-mcp config set <key> <value> [--project|--global]',
+      get: 'search-console-mcp config get <key> [--project|--global]'
+    }
+  }, null, 2));
+}

--- a/src/cli/global-flags.ts
+++ b/src/cli/global-flags.ts
@@ -1,0 +1,39 @@
+export interface ParsedGlobalFlags {
+  argv: string[];
+  credentialsPath?: string;
+}
+
+export function parseGlobalFlags(argv: string[]): ParsedGlobalFlags {
+  const normalized: string[] = [];
+  let credentialsPath: string | undefined;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg.startsWith('--credentials=')) {
+      credentialsPath = arg.slice('--credentials='.length);
+      continue;
+    }
+
+    if (arg === '--credentials') {
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        credentialsPath = next;
+        i += 1;
+      }
+      continue;
+    }
+
+    normalized.push(arg);
+  }
+
+  return { argv: normalized, credentialsPath };
+}
+
+export function applyGlobalFlags(parsed: ParsedGlobalFlags): string[] {
+  if (parsed.credentialsPath) {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = parsed.credentialsPath;
+  }
+
+  return parsed.argv;
+}

--- a/src/cli/output/formatter.ts
+++ b/src/cli/output/formatter.ts
@@ -1,0 +1,81 @@
+import { jsonToCsv } from "../../common/utils/csv.js";
+
+export type OutputMode = "table" | "json" | "csv" | "tsv";
+export type RawRecord = Record<string, unknown>;
+
+function normalizeValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+}
+
+function collectHeaders(records: RawRecord[]): string[] {
+  const headerSet = new Set<string>();
+  for (const record of records) {
+    Object.keys(record).forEach((key) => headerSet.add(key));
+  }
+  return Array.from(headerSet);
+}
+
+function toSeparatedValues(records: RawRecord[], delimiter: "," | "\t"): string {
+  if (records.length === 0) {
+    return "";
+  }
+
+  if (delimiter === ",") {
+    return jsonToCsv(records);
+  }
+
+  const headers = collectHeaders(records);
+  const lines = [headers.join(delimiter)];
+
+  for (const row of records) {
+    lines.push(headers.map((header) => normalizeValue(row[header])).join(delimiter));
+  }
+
+  return lines.join("\n");
+}
+
+function toTable(records: RawRecord[]): string {
+  if (records.length === 0) {
+    return "(no rows)";
+  }
+
+  const headers = collectHeaders(records);
+  const rows = records.map((row) => headers.map((header) => normalizeValue(row[header])));
+  const widths = headers.map((header, idx) => Math.max(header.length, ...rows.map((row) => row[idx].length)));
+
+  const formatLine = (cols: string[]) => cols.map((col, idx) => col.padEnd(widths[idx])).join(" | ");
+  const separator = widths.map((width) => "-".repeat(width)).join("-+-");
+
+  return [
+    formatLine(headers),
+    separator,
+    ...rows.map((row) => formatLine(row))
+  ].join("\n");
+}
+
+export function formatRecords(records: RawRecord[], mode: OutputMode): string {
+  switch (mode) {
+    case "json":
+      return JSON.stringify(records, null, 2);
+    case "csv":
+      return toSeparatedValues(records, ",");
+    case "tsv":
+      return toSeparatedValues(records, "\t");
+    case "table":
+      return toTable(records);
+    default:
+      return JSON.stringify(records, null, 2);
+  }
+}

--- a/src/cli/router.ts
+++ b/src/cli/router.ts
@@ -1,0 +1,41 @@
+import { LegacyCommand, LegacyCommandAdapters } from './adapters.js';
+
+const legacyCommands: LegacyCommand[] = ['setup', 'account', 'accounts', 'logout', 'login', 'diagnostics', 'sites'];
+
+export function shouldStartMcp(command?: string): boolean {
+  return !command || !legacyCommands.includes(command as LegacyCommand);
+}
+
+export async function routeLegacyCommand(
+  command: string | undefined,
+  args: string[],
+  adapters: LegacyCommandAdapters
+): Promise<boolean> {
+  if (!command) {
+    return false;
+  }
+
+  switch (command) {
+    case 'setup':
+      await adapters.setup();
+      return true;
+    case 'account':
+    case 'accounts':
+      await adapters.accounts(args);
+      return true;
+    case 'logout':
+      await adapters.logout();
+      return true;
+    case 'login':
+      await adapters.login();
+      return true;
+    case 'diagnostics':
+      await adapters.diagnostics();
+      return true;
+    case 'sites':
+      await adapters.sites();
+      return true;
+    default:
+      return false;
+  }
+}

--- a/src/cli/router.ts
+++ b/src/cli/router.ts
@@ -1,6 +1,6 @@
 import { LegacyCommand, LegacyCommandAdapters } from './adapters.js';
 
-const legacyCommands: LegacyCommand[] = ['setup', 'account', 'accounts', 'logout', 'login', 'diagnostics', 'sites'];
+const legacyCommands: LegacyCommand[] = ['setup', 'account', 'accounts', 'logout', 'login', 'auth', 'diagnostics', 'sites'];
 
 export function shouldStartMcp(command?: string): boolean {
   return !command || !legacyCommands.includes(command as LegacyCommand);
@@ -28,6 +28,9 @@ export async function routeLegacyCommand(
       return true;
     case 'login':
       await adapters.login();
+      return true;
+    case 'auth':
+      await adapters.auth(args);
       return true;
     case 'diagnostics':
       await adapters.diagnostics();

--- a/src/cli/router.ts
+++ b/src/cli/router.ts
@@ -1,6 +1,6 @@
 import { LegacyCommand, LegacyCommandAdapters } from './adapters.js';
 
-const legacyCommands: LegacyCommand[] = ['setup', 'account', 'accounts', 'logout', 'login', 'auth', 'diagnostics', 'sites'];
+const legacyCommands: LegacyCommand[] = ['setup', 'account', 'accounts', 'logout', 'login', 'auth', 'diagnostics', 'sites', 'config'];
 
 export function shouldStartMcp(command?: string): boolean {
   return !command || !legacyCommands.includes(command as LegacyCommand);
@@ -37,6 +37,9 @@ export async function routeLegacyCommand(
       return true;
     case 'sites':
       await adapters.sites();
+      return true;
+    case 'config':
+      await adapters.config(args);
       return true;
     default:
       return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ import { runDiagnostics } from "./common/diagnostics.js";
 import { logger } from "./utils/logger.js";
 import { createLegacyCommandAdapters } from "./cli/adapters.js";
 import { routeLegacyCommand } from "./cli/router.js";
+import { applyGlobalFlags, parseGlobalFlags } from "./cli/global-flags.js";
 import { getAnalyticsQueryRawRecords, getBingAnalyticsQueryRawRecords, getGa4PagePerformanceRawRecords } from "./cli/commands/analytics.js";
 import { formatRecords } from "./cli/output/formatter.js";
 
@@ -2597,9 +2598,11 @@ server.tool(
 );
 
 async function main() {
-  const command = process.argv[2];
+  const parsed = parseGlobalFlags(process.argv.slice(2));
+  const argv = applyGlobalFlags(parsed);
+  const command = argv[0];
 
-  const handled = await routeLegacyCommand(command, process.argv.slice(3), await createLegacyCommandAdapters());
+  const handled = await routeLegacyCommand(command, argv.slice(1), await createLegacyCommandAdapters());
   if (handled) {
     return;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,8 @@ import { registerPrompts } from "./prompts/index.js";
 import { jsonToCsv } from "./common/utils/csv.js";
 import { runDiagnostics } from "./common/diagnostics.js";
 import { logger } from "./utils/logger.js";
+import { createLegacyCommandAdapters } from "./cli/adapters.js";
+import { routeLegacyCommand } from "./cli/router.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -2629,40 +2631,8 @@ server.tool(
 async function main() {
   const command = process.argv[2];
 
-  // Handle standalone commands
-  if (command === 'setup') {
-    const { main: setupMain } = await import('./setup.js');
-    await setupMain();
-    return;
-  }
-
-  if (command === 'account' || command === 'accounts') {
-    const { main: accountsMain } = await import('./accounts.js');
-    await accountsMain(process.argv.slice(3));
-    return;
-  }
-
-  if (command === 'logout') {
-    const { runLogout } = await import('./setup.js');
-    await runLogout();
-    return;
-  }
-
-  if (command === 'login') {
-    const { login } = await import('./setup.js');
-    await login();
-    return;
-  }
-
-  if (command === 'diagnostics') {
-    const results = await runDiagnostics();
-    console.log(JSON.stringify(results, null, 2));
-    return;
-  }
-
-  if (command === 'sites') {
-    const { main: accountsMain } = await import('./accounts.js');
-    await accountsMain(['list']);
+  const handled = await routeLegacyCommand(command, process.argv.slice(3), await createLegacyCommandAdapters());
+  if (handled) {
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,11 +57,12 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { getStartedHandler, getStartedToolName, getStartedToolDescription, getStartedToolSchema } from "./common/tools/get-started.js";
 import { registerPrompts } from "./prompts/index.js";
-import { jsonToCsv } from "./common/utils/csv.js";
 import { runDiagnostics } from "./common/diagnostics.js";
 import { logger } from "./utils/logger.js";
 import { createLegacyCommandAdapters } from "./cli/adapters.js";
 import { routeLegacyCommand } from "./cli/router.js";
+import { getAnalyticsQueryRawRecords, getBingAnalyticsQueryRawRecords, getGa4PagePerformanceRawRecords } from "./cli/commands/analytics.js";
+import { formatRecords } from "./cli/output/formatter.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -426,29 +427,10 @@ server.tool(
   },
   async (args) => {
     try {
-      const result = await analytics.queryAnalytics(args);
-
-      if (args.format === 'csv') {
-        const flatData = result.map(row => {
-          const newRow: any = { ...row };
-          if (row.keys && Array.isArray(row.keys)) {
-            row.keys.forEach((keyVal, idx) => {
-              const dimName = args.dimensions && args.dimensions[idx]
-                ? args.dimensions[idx]
-                : `dimension_${idx + 1}`;
-              newRow[dimName] = keyVal;
-            });
-            delete newRow.keys;
-          }
-          return newRow;
-        });
-        return {
-          content: [{ type: "text", text: jsonToCsv(flatData) }]
-        };
-      }
-
+      const rawRecords = await getAnalyticsQueryRawRecords(args);
+      const mode = args.format === "csv" ? "csv" : "json";
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        content: [{ type: "text", text: formatRecords(rawRecords, mode) }]
       };
     } catch (error) {
       return formatError(error);
@@ -1283,20 +1265,10 @@ server.tool(
   },
   async ({ siteUrl, startDate, endDate, limit, format }) => {
     try {
-      let results = await bingAnalytics.getQueryStats(siteUrl, startDate, endDate);
-
-      if (limit) {
-        results = results.slice(0, limit);
-      }
-
-      if (format === 'csv') {
-        return {
-          content: [{ type: "text", text: jsonToCsv(results) }]
-        };
-      }
-
+      const rawRecords = await getBingAnalyticsQueryRawRecords({ siteUrl, startDate, endDate, limit });
+      const mode = format === "csv" ? "csv" : "json";
       return {
-        content: [{ type: "text", text: JSON.stringify(results, null, 2) }]
+        content: [{ type: "text", text: formatRecords(rawRecords, mode) }]
       };
     } catch (error) {
       return formatError(error);
@@ -1802,14 +1774,10 @@ server.tool(
   },
   async ({ propertyId, accountId, startDate, endDate, pagePath, limit, offset, format }) => {
     try {
-      const result = await ga4Analytics.getPagePerformance(propertyId, startDate, endDate, pagePath, limit, accountId, offset);
-      if (format === 'csv') {
-        return {
-          content: [{ type: "text", text: jsonToCsv(result) }]
-        };
-      }
+      const rawRecords = await getGa4PagePerformanceRawRecords({ propertyId, accountId, startDate, endDate, pagePath, limit, offset });
+      const mode = format === "csv" ? "csv" : "json";
       return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        content: [{ type: "text", text: formatRecords(rawRecords, mode) }]
       };
     } catch (error) {
       return formatError(error);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'dotenv/config';
-import { readFileSync, existsSync, statSync, writeFileSync } from 'fs';
+import { readFileSync, existsSync, statSync, writeFileSync, mkdirSync } from 'fs';
 import { resolve, dirname, extname, join } from 'path';
 import { createInterface } from 'readline';
 import { homedir } from 'os';
@@ -15,6 +15,30 @@ import { colors, printBoxHeader, printStatusLine } from './utils/ui.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+const GLOBAL_CLI_CONFIG_DIR = join(homedir(), '.search-console-mcp');
+const GLOBAL_CLI_CONFIG_PATH = join(GLOBAL_CLI_CONFIG_DIR, 'config.json');
+
+function persistCredentialsPath(credentialsPath: string): void {
+    try {
+        if (!existsSync(GLOBAL_CLI_CONFIG_DIR)) {
+            mkdirSync(GLOBAL_CLI_CONFIG_DIR, { recursive: true, mode: 0o700 });
+        }
+
+        let config: Record<string, unknown> = {};
+        if (existsSync(GLOBAL_CLI_CONFIG_PATH)) {
+            const raw = readFileSync(GLOBAL_CLI_CONFIG_PATH, 'utf8').trim();
+            if (raw) {
+                config = JSON.parse(raw) as Record<string, unknown>;
+            }
+        }
+
+        config.credentialsPath = credentialsPath;
+        writeFileSync(GLOBAL_CLI_CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+    } catch {
+        // Persisting CLI preferences is best-effort and should never block setup.
+    }
+}
 
 const rl = createInterface({
     input: process.stdin,
@@ -426,6 +450,7 @@ async function setupServiceAccount() {
         serviceAccountPath: credentialsPath
     };
     await updateAccount(account);
+    persistCredentialsPath(credentialsPath);
     printSuccess(`Successfully added account ${alias}!`);
 
     printStep(4, 'Configure your MCP client');

--- a/tests/__snapshots__/cli-output-format.test.ts.snap
+++ b/tests/__snapshots__/cli-output-format.test.ts.snap
@@ -1,0 +1,37 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`cli output formatter > formats csv output consistently 1`] = `
+"site,clicks,ctr,active
+https://example.com,120,0.2,true
+https://example.org,98,0.15,false"
+`;
+
+exports[`cli output formatter > formats json output consistently 1`] = `
+"[
+  {
+    "site": "https://example.com",
+    "clicks": 120,
+    "ctr": 0.2,
+    "active": true
+  },
+  {
+    "site": "https://example.org",
+    "clicks": 98,
+    "ctr": 0.15,
+    "active": false
+  }
+]"
+`;
+
+exports[`cli output formatter > formats table output consistently 1`] = `
+"site                | clicks | ctr  | active
+--------------------+--------+------+-------
+https://example.com | 120    | 0.2  | true  
+https://example.org | 98     | 0.15 | false "
+`;
+
+exports[`cli output formatter > formats tsv output consistently 1`] = `
+"site	clicks	ctr	active
+https://example.com	120	0.2	true
+https://example.org	98	0.15	false"
+`;

--- a/tests/auth-cli.test.ts
+++ b/tests/auth-cli.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { main } from '../src/auth.js';
+
+vi.mock('../src/common/auth/config.js', () => ({
+  loadConfig: vi.fn(),
+  removeAccount: vi.fn()
+}));
+
+vi.mock('../src/google/client.js', () => ({
+  logout: vi.fn()
+}));
+
+describe('auth CLI commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prints account status from unified config', async () => {
+    const { loadConfig } = await import('../src/common/auth/config.js');
+    vi.mocked(loadConfig).mockResolvedValue({
+      accounts: {
+        google_1: {
+          id: 'google_1',
+          alias: 'user@example.com',
+          engine: 'google',
+          tokens: { refresh_token: 'rt' },
+          isLegacy: false
+        },
+        legacy_bing: {
+          id: 'legacy_bing',
+          alias: 'Bing API Key (env)',
+          engine: 'bing',
+          isLegacy: true,
+          apiKey: 'redacted'
+        }
+      }
+    } as any);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await main(['status']);
+
+    const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(output.summary.total).toBe(2);
+    expect(output.accounts[1].legacy).toBe(true);
+    expect(output.storage.config).toContain('.search-console-mcp-config.enc');
+  });
+
+  it('revokes google accounts via logout helper', async () => {
+    const { loadConfig } = await import('../src/common/auth/config.js');
+    const { logout } = await import('../src/google/client.js');
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      accounts: {
+        google_1: {
+          id: 'google_1',
+          alias: 'user@example.com',
+          engine: 'google'
+        }
+      }
+    } as any);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await main(['revoke', '--account=google_1']);
+
+    expect(logout).toHaveBeenCalledWith('google_1');
+    expect(JSON.parse(consoleSpy.mock.calls[0][0]).success).toBe(true);
+  });
+
+  it('revokes non-google accounts via config removal', async () => {
+    const { loadConfig, removeAccount } = await import('../src/common/auth/config.js');
+    vi.mocked(loadConfig).mockResolvedValue({
+      accounts: {
+        bing_1: {
+          id: 'bing_1',
+          alias: 'Bing 1',
+          engine: 'bing'
+        }
+      }
+    } as any);
+
+    await main(['revoke', '--all']);
+
+    expect(removeAccount).toHaveBeenCalledWith('bing_1');
+  });
+});

--- a/tests/cli-output-format.test.ts
+++ b/tests/cli-output-format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { formatRecords } from '../src/cli/output/formatter.js';
+
+describe('cli output formatter', () => {
+  const records = [
+    { site: 'https://example.com', clicks: 120, ctr: 0.2, active: true },
+    { site: 'https://example.org', clicks: 98, ctr: 0.15, active: false }
+  ];
+
+  it('formats json output consistently', () => {
+    expect(formatRecords(records, 'json')).toMatchSnapshot();
+  });
+
+  it('formats csv output consistently', () => {
+    expect(formatRecords(records, 'csv')).toMatchSnapshot();
+  });
+
+  it('formats tsv output consistently', () => {
+    expect(formatRecords(records, 'tsv')).toMatchSnapshot();
+  });
+
+  it('formats table output consistently', () => {
+    expect(formatRecords(records, 'table')).toMatchSnapshot();
+  });
+
+  it('formats empty table as no rows marker', () => {
+    expect(formatRecords([], 'table')).toBe('(no rows)');
+  });
+});

--- a/tests/cli-routing.test.ts
+++ b/tests/cli-routing.test.ts
@@ -8,6 +8,7 @@ function createAdapters() {
     accounts: vi.fn(async (_args: string[]) => {}),
     logout: vi.fn(async () => {}),
     login: vi.fn(async () => {}),
+    auth: vi.fn(async (_args: string[]) => {}),
     diagnostics: vi.fn(async () => {}),
     sites: vi.fn(async () => {})
   };
@@ -37,6 +38,9 @@ describe('CLI command routing compatibility', () => {
 
     expect(await routeLegacyCommand('logout', [], adapters)).toBe(true);
     expect(adapters.logout).toHaveBeenCalledTimes(1);
+
+    expect(await routeLegacyCommand('auth', ['status'], adapters)).toBe(true);
+    expect(adapters.auth).toHaveBeenCalledWith(['status']);
 
     expect(await routeLegacyCommand('diagnostics', [], adapters)).toBe(true);
     expect(adapters.diagnostics).toHaveBeenCalledTimes(1);

--- a/tests/cli-routing.test.ts
+++ b/tests/cli-routing.test.ts
@@ -10,7 +10,8 @@ function createAdapters() {
     login: vi.fn(async () => {}),
     auth: vi.fn(async (_args: string[]) => {}),
     diagnostics: vi.fn(async () => {}),
-    sites: vi.fn(async () => {})
+    sites: vi.fn(async () => {}),
+    config: vi.fn(async (_args: string[]) => {})
   };
 
   return adapters;
@@ -19,6 +20,11 @@ function createAdapters() {
 describe('CLI command routing compatibility', () => {
   it('keeps MCP mode active when no command is provided', () => {
     expect(shouldStartMcp(undefined)).toBe(true);
+  });
+
+
+  it('keeps MCP mode disabled for legacy config command', () => {
+    expect(shouldStartMcp('config')).toBe(false);
   });
 
   it('routes legacy commands through shared adapters', async () => {
@@ -47,6 +53,9 @@ describe('CLI command routing compatibility', () => {
 
     expect(await routeLegacyCommand('sites', [], adapters)).toBe(true);
     expect(adapters.sites).toHaveBeenCalledTimes(1);
+
+    expect(await routeLegacyCommand('config', ['get', 'credentials.path'], adapters)).toBe(true);
+    expect(adapters.config).toHaveBeenCalledWith(['get', 'credentials.path']);
   });
 
   it('does not consume unknown commands as legacy commands', async () => {

--- a/tests/cli-routing.test.ts
+++ b/tests/cli-routing.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { routeLegacyCommand, shouldStartMcp } from '../src/cli/router.js';
+import { LegacyCommandAdapters } from '../src/cli/adapters.js';
+
+function createAdapters() {
+  const adapters: LegacyCommandAdapters = {
+    setup: vi.fn(async () => {}),
+    accounts: vi.fn(async (_args: string[]) => {}),
+    logout: vi.fn(async () => {}),
+    login: vi.fn(async () => {}),
+    diagnostics: vi.fn(async () => {}),
+    sites: vi.fn(async () => {})
+  };
+
+  return adapters;
+}
+
+describe('CLI command routing compatibility', () => {
+  it('keeps MCP mode active when no command is provided', () => {
+    expect(shouldStartMcp(undefined)).toBe(true);
+  });
+
+  it('routes legacy commands through shared adapters', async () => {
+    const adapters = createAdapters();
+
+    expect(await routeLegacyCommand('setup', [], adapters)).toBe(true);
+    expect(adapters.setup).toHaveBeenCalledTimes(1);
+
+    expect(await routeLegacyCommand('accounts', ['list'], adapters)).toBe(true);
+    expect(adapters.accounts).toHaveBeenCalledWith(['list']);
+
+    expect(await routeLegacyCommand('account', ['list'], adapters)).toBe(true);
+    expect(adapters.accounts).toHaveBeenCalledWith(['list']);
+
+    expect(await routeLegacyCommand('login', [], adapters)).toBe(true);
+    expect(adapters.login).toHaveBeenCalledTimes(1);
+
+    expect(await routeLegacyCommand('logout', [], adapters)).toBe(true);
+    expect(adapters.logout).toHaveBeenCalledTimes(1);
+
+    expect(await routeLegacyCommand('diagnostics', [], adapters)).toBe(true);
+    expect(adapters.diagnostics).toHaveBeenCalledTimes(1);
+
+    expect(await routeLegacyCommand('sites', [], adapters)).toBe(true);
+    expect(adapters.sites).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not consume unknown commands as legacy commands', async () => {
+    const adapters = createAdapters();
+    expect(await routeLegacyCommand('unknown-command', [], adapters)).toBe(false);
+  });
+});

--- a/tests/global-flags.test.ts
+++ b/tests/global-flags.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { applyGlobalFlags, parseGlobalFlags } from '../src/cli/global-flags.js';
+
+describe('CLI global flags', () => {
+  const originalCredentials = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+  beforeEach(() => {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = originalCredentials;
+  });
+
+  it('extracts --credentials=value and strips it from argv', () => {
+    const parsed = parseGlobalFlags(['--credentials=/tmp/key.json', 'auth', 'status']);
+
+    expect(parsed.credentialsPath).toBe('/tmp/key.json');
+    expect(parsed.argv).toEqual(['auth', 'status']);
+  });
+
+  it('extracts --credentials <value> and strips both tokens', () => {
+    const parsed = parseGlobalFlags(['auth', '--credentials', '/tmp/key.json', 'status']);
+
+    expect(parsed.credentialsPath).toBe('/tmp/key.json');
+    expect(parsed.argv).toEqual(['auth', 'status']);
+  });
+
+  it('applies parsed credentials into GOOGLE_APPLICATION_CREDENTIALS', () => {
+    const argv = applyGlobalFlags(parseGlobalFlags(['--credentials=/tmp/key.json', 'sites']));
+
+    expect(process.env.GOOGLE_APPLICATION_CREDENTIALS).toBe('/tmp/key.json');
+    expect(argv).toEqual(['sites']);
+  });
+});

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["cli/**/*", "src/cli/**/*"]
+}


### PR DESCRIPTION
### Motivation
- Preserve existing MCP stdio bootstrap behavior in `src/index.ts` while enabling a human-facing CLI without breaking integrations. 
- Consolidate legacy operational commands (`setup`, `accounts`/`account`, `login`, `logout`, `diagnostics`, `sites`) behind shared adapters to avoid behavior drift between entrypoints. 
- Provide a clear compatibility design and a safe packaging strategy so both MCP and CLI binaries can coexist.

### Description
- Added a compatibility design document at `docs/cli-compatibility-design.md` explaining the routing strategy and packaging approach. 
- Introduced shared adapters in `src/cli/adapters.ts` and a router in `src/cli/router.ts` to centralize legacy command handling. 
- Updated `src/index.ts` to delegate legacy commands to the shared router first and only start MCP stdio transport when no legacy subcommand is handled. 
- Scaffoled a human-facing dispatcher at `cli/index.ts` that reuses the same adapters and prints CLI help for non-legacy commands. 
- Updated packaging and build to add a second bin (`search-console-cli`) while preserving `search-console-mcp`, and added `tsconfig.cli.json` so the CLI compiles to `dist/cli/index.js`. 
- Added regression tests in `tests/cli-routing.test.ts` validating MCP default behavior and legacy command routing.

### Testing
- Ran `npm run build` (which now runs `tsc` and `tsc -p tsconfig.cli.json`) and the build completed successfully. 
- Ran `npm test -- tests/cli-routing.test.ts` and the new test file executed successfully (`3 tests passed`). 
- Ran `npm test -- tests/setup-cli.test.ts` to validate existing CLI behavior and it passed (`4 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b425a622e48329960f809e513dcafa)