### PR TITLE
Add tenant-scoped HTTP authorization and secret-safe multi-account isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,106 @@ When your AI agent queries a site, the server automatically resolves which accou
 
 ---
 
+## 🏢 Multi-Tenant HTTP Mode
+
+For agency and multi-agent deployments, run the server in tenant mode so a bearer token is authorized before any account resolver can select Google, Bing, or GA4 credentials.
+
+Tenant mode changes the security model from:
+
+```text
+siteUrl -> account resolver -> credentials
+```
+
+to:
+
+```text
+Bearer token -> tenant -> allowed tools/sites/engines -> account resolver -> credentials
+```
+
+### Configuration
+
+```bash
+export MCP_REQUIRE_TENANT_TOKEN=true
+export MCP_PRODUCTION_MODE=true
+export MCP_TENANTS_DIR=/etc/search-console-mcp/tenants
+export MCP_TOKEN_REGISTRY=/etc/search-console-mcp/tokens/tokens.json
+export MCP_BIND_HOST=127.0.0.1
+export MCP_PORT=3001
+
+npx search-console-mcp serve-http
+```
+
+In production mode the HTTP server refuses public wildcard binds such as `0.0.0.0` unless `MCP_ALLOW_PUBLIC_BIND=true` is set explicitly. Bind to localhost, a Tailscale address, or place the endpoint behind a private reverse proxy with access control.
+
+Example tenant file:
+
+```json
+{
+  "tenant_id": "astrogen",
+  "display_name": "Astrogen",
+  "enabled": true,
+  "engines": {
+    "google": {
+      "account_ids": ["google_astrogen"],
+      "allowed_sites": ["sc-domain:astrogen.com.ua"],
+      "default_site": "sc-domain:astrogen.com.ua"
+    },
+    "bing": {
+      "account_ids": [],
+      "allowed_sites": []
+    },
+    "ga4": {
+      "account_ids": [],
+      "allowed_properties": []
+    }
+  },
+  "allowed_tools": ["get_started", "sites_list", "analytics_*", "seo_*", "inspection_*", "pagespeed_*", "schema_validate"],
+  "denied_tools": ["sites_add", "sites_delete", "sitemaps_submit", "sitemaps_delete", "bing_index_now"],
+  "limits": {
+    "max_rows": 25000,
+    "max_batch_urls": 10,
+    "request_timeout_seconds": 120
+  }
+}
+```
+
+Token registry entries store only SHA-256 token hashes:
+
+```json
+{
+  "tokens": [
+    {
+      "token_id": "astrogen-primary",
+      "tenant_id": "astrogen",
+      "token_hash": "sha256:<hex>",
+      "enabled": true
+    }
+  ]
+}
+```
+
+### Tenant CLI
+
+```bash
+npx search-console-mcp tenants list
+npx search-console-mcp tenants validate
+npx search-console-mcp tenants add --tenant=astrogen --site=sc-domain:astrogen.com.ua
+npx search-console-mcp tokens create --tenant=astrogen --description="Astrogen agent"
+npx search-console-mcp tokens revoke --token-id=astrogen-primary
+```
+
+`tokens create` prints the plaintext bearer token once and stores only the hash. Do not reuse shared deployment keys as tenant bearer tokens.
+
+### Tenant Security Notes
+
+* `sites_list` returns only the authenticated tenant's allowlisted sites or properties.
+* Account management and mutating tools are disabled for tenants unless explicitly enabled in tenant configuration.
+* PageSpeed, CrUX, schema validation, and IndexNow are tenant-scoped even though they do not always require Search Console credentials.
+* IndexNow keys should be configured server-side under tenant config and must not be sent as MCP tool arguments in tenant HTTP mode.
+* Logs and MCP errors redact bearer tokens, API keys, token hashes, private keys, and common secret fields.
+
+---
+
 
 ## 🛡️ Fort Knox Security
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "search-console-mcp",
-  "version": "1.13.3",
+  "version": "1.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search-console-mcp",
-      "version": "1.13.3",
+      "version": "1.13.5",
       "license": "MIT",
       "dependencies": {
         "@adobe/structured-data-validator": "^1.7.0",
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1051,9 +1051,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
       "cpu": [
         "arm"
       ],
@@ -1065,9 +1065,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
       ],
@@ -1079,9 +1079,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
       "cpu": [
         "arm64"
       ],
@@ -1093,9 +1093,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
       ],
@@ -1107,9 +1107,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
       "cpu": [
         "arm64"
       ],
@@ -1121,9 +1121,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
       ],
@@ -1135,9 +1135,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
         "arm"
       ],
@@ -1149,9 +1149,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
       ],
@@ -1163,9 +1163,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
       ],
@@ -1177,9 +1177,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
       ],
@@ -1191,9 +1191,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
       "cpu": [
         "loong64"
       ],
@@ -1205,9 +1205,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
       ],
@@ -1219,9 +1219,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
       "cpu": [
         "ppc64"
       ],
@@ -1233,9 +1233,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1247,9 +1247,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
       "cpu": [
         "riscv64"
       ],
@@ -1261,9 +1261,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1275,9 +1275,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
       "cpu": [
         "s390x"
       ],
@@ -1289,9 +1289,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
@@ -1303,9 +1303,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
       ],
@@ -1317,9 +1317,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
       "cpu": [
         "x64"
       ],
@@ -1331,9 +1331,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
       "cpu": [
         "arm64"
       ],
@@ -1345,9 +1345,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
       "cpu": [
         "arm64"
       ],
@@ -1359,9 +1359,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
       "cpu": [
         "ia32"
       ],
@@ -1373,9 +1373,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
       "cpu": [
         "x64"
       ],
@@ -1387,9 +1387,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
       "cpu": [
         "x64"
       ],
@@ -1455,15 +1455,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1783,12 +1774,12 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/base64-js": {
@@ -1851,15 +1842,15 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -1941,12 +1932,12 @@
       }
     },
     "node_modules/cacache/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2747,12 +2738,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3174,9 +3165,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
-      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3314,9 +3305,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3700,18 +3691,33 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/minipass": {
@@ -4179,9 +4185,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4203,9 +4209,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4224,9 +4230,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -4299,9 +4305,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4466,9 +4472,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4482,31 +4488,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -4962,9 +4968,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -4978,57 +4984,18 @@
       }
     },
     "node_modules/teeny-request": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.0.tgz",
-      "integrity": "sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.2.tgz",
+      "integrity": "sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
         "node-fetch": "^3.3.2",
         "stream-events": "^1.0.5"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/teeny-request/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/teeny-request/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/teeny-request/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/tinybench": {
@@ -5143,9 +5110,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.20.0.tgz",
-      "integrity": "sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -5212,9 +5179,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5571,9 +5538,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -999,25 +999,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -1027,9 +1026,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1045,9 +1044,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1842,9 +1841,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2738,12 +2737,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2768,9 +2767,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -3165,9 +3164,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3305,9 +3304,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4305,24 +4304,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4352,9 +4351,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/src/bing/client.ts
+++ b/src/bing/client.ts
@@ -1,5 +1,8 @@
 import { resolveAccount } from '../common/auth/resolver.js';
 import { loadConfig } from '../common/auth/config.js';
+import { getCurrentTenant } from '../tenant/context.js';
+import { assertAccountIdAllowed } from '../tenant/guard.js';
+import { sanitizeForLog } from '../utils/redaction.js';
 
 export interface BingSite {
     Url: string;
@@ -116,7 +119,7 @@ export class BingClient {
         const response = await fetch(url.toString(), options);
         if (!response.ok) {
             const error = await response.text();
-            throw new Error(`Bing API error (${method}): ${response.status} ${error}`);
+            throw new Error(sanitizeForLog(`Bing API error (${method}): ${response.status} ${error}`));
         }
 
         const data = await response.json() as any;
@@ -215,6 +218,8 @@ export async function getBingClient(siteUrl?: string, accountId?: string): Promi
     let cacheKey: string;
 
     if (accountId) {
+        const tenant = getCurrentTenant();
+        if (tenant) assertAccountIdAllowed(tenant, accountId, 'bing');
         const config = await loadConfig();
         const account = config.accounts[accountId];
         if (!account || account.engine !== 'bing') {
@@ -228,6 +233,9 @@ export async function getBingClient(siteUrl?: string, accountId?: string): Promi
             apiKey = account.apiKey;
             cacheKey = account.id;
         } catch (error) {
+            if (getCurrentTenant()) {
+                throw error;
+            }
             // Fallback to environment variable for legacy support if resolution fails or no site specified
             apiKey = process.env.BING_API_KEY;
             cacheKey = 'env_fallback';

--- a/src/bing/docs/index.ts
+++ b/src/bing/docs/index.ts
@@ -105,7 +105,7 @@ IndexNow is a simple way for website owners to instantly inform search engines a
 ## Tool: \`bing_index_now\`
 Arguments:
 - \`host\`: The domain (e.g., \`www.example.com\`).
-- \`key\`: Your generated IndexNow key.
+- \`key\`: Your generated IndexNow key. In tenant HTTP mode this is resolved from server-side tenant configuration and must not be sent by the MCP client.
 - \`keyLocation\` (optional): The URL where the key is hosted if not at the root.
 - \`urlList\`: An array of URLs that have changed.
 

--- a/src/bing/docs/patterns.ts
+++ b/src/bing/docs/patterns.ts
@@ -23,7 +23,6 @@ Instantly notify Bing of new content using IndexNow (preferred over sitemaps for
 Tool: bing_index_now
 Args: { 
   "host": "www.example.com",
-  "key": "YOUR_KEY",
   "urlList": ["https://www.example.com/new-page"]
 }
 \`\`\`

--- a/src/common/auth/resolver.ts
+++ b/src/common/auth/resolver.ts
@@ -1,4 +1,6 @@
 import { AccountConfig, loadConfig, EngineType } from './config.js';
+import { getCurrentTenant } from '../../tenant/context.js';
+import { resolveTenantAccount } from '../../tenant/guard.js';
 
 export interface ResolutionError extends Error {
     code: 'FORBIDDEN' | 'AMBIGUOUS' | 'NOT_FOUND';
@@ -34,6 +36,11 @@ export function normalizeWebsite(site: string): { type: 'domain' | 'url-prefix';
  * Resolves the best account for a given siteUrl and engine.
  */
 export async function resolveAccount(siteUrl: string, engine: EngineType): Promise<AccountConfig> {
+    const tenant = getCurrentTenant();
+    if (tenant) {
+        return resolveTenantAccount(tenant, siteUrl, engine);
+    }
+
     const config = await loadConfig();
     const accounts = Object.values(config.accounts).filter(a => a.engine === engine);
 

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -1,3 +1,5 @@
+import { sanitizeForLog } from '../utils/redaction.js';
+
 /**
  * Error handling utilities for the MCP server
  */
@@ -30,6 +32,18 @@ function getErrorMessage(error: unknown): string {
         // Handle Google API errors
         const anyError = error as any;
 
+        if (anyError.status === 401 || anyError.code === 'UNAUTHORIZED') {
+            return sanitizeForLog(error.message || "Authentication failed.");
+        }
+
+        if (anyError.status === 403 || anyError.code === 'FORBIDDEN') {
+            return sanitizeForLog(error.message || "Forbidden.");
+        }
+
+        if (anyError.status === 404 || anyError.code === 'NOT_FOUND') {
+            return sanitizeForLog(error.message || "Resource not found.");
+        }
+
         // Rate limiting
         if (anyError.code === 429 || anyError.status === 429) {
             return "Rate limit exceeded. Please wait a moment and try again.";
@@ -52,11 +66,11 @@ function getErrorMessage(error: unknown): string {
 
         // Google API error with message
         if (anyError.errors && Array.isArray(anyError.errors) && anyError.errors.length > 0) {
-            return anyError.errors[0].message || error.message;
+            return sanitizeForLog(anyError.errors[0].message || error.message);
         }
 
-        return error.message;
+        return sanitizeForLog(error.message);
     }
 
-    return String(error);
+    return sanitizeForLog(String(error));
 }

--- a/src/common/tools/schema-validator.ts
+++ b/src/common/tools/schema-validator.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import Validator from '@adobe/structured-data-validator';
 import * as cheerio from 'cheerio';
+import { sanitizeForLog } from '../../utils/redaction.js';
 
 /**
  * Result of a structured data (schema) validation check.
@@ -31,14 +32,14 @@ export async function validateSchema(
     try {
         if (type === 'url') {
             try {
-                const response = await fetch(input);
+                const response = await fetchSchemaUrl(input);
                 if (!response.ok) {
                     throw new Error(`Failed to fetch URL: ${response.status} ${response.statusText}`);
                 }
-                const html = await response.text();
+                const html = await readLimitedText(response, 1_000_000);
                 schemas = extractSchemas(html);
             } catch (e: any) {
-                return { valid: false, errors: [`Fetch error: ${e.message}`], schemas: [] };
+                return { valid: false, errors: [`Fetch error: ${sanitizeForLog(e.message)}`], schemas: [] };
             }
         } else if (type === 'html') {
             schemas = extractSchemas(input);
@@ -94,6 +95,88 @@ export async function validateSchema(
     } catch (err: any) {
         return { valid: false, errors: [err.message], schemas: [] };
     }
+}
+
+async function fetchSchemaUrl(input: string): Promise<Response> {
+    const url = new URL(input);
+    if (!['http:', 'https:'].includes(url.protocol)) {
+        throw new Error('Only http and https URLs are allowed');
+    }
+    if (isBlockedHost(url.hostname)) {
+        throw new Error('URL host is not allowed');
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+    try {
+        return await fetch(url.toString(), {
+            redirect: 'follow',
+            signal: controller.signal
+        });
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+async function readLimitedText(response: Response, maxBytes: number): Promise<string> {
+    const contentLength = response.headers?.get?.('content-length');
+    if (contentLength && Number(contentLength) > maxBytes) {
+        throw new Error('Response is too large');
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) return response.text();
+
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        total += value.byteLength;
+        if (total > maxBytes) {
+            throw new Error('Response is too large');
+        }
+        chunks.push(value);
+    }
+
+    return new TextDecoder().decode(concatChunks(chunks, total));
+}
+
+function concatChunks(chunks: Uint8Array[], total: number): Uint8Array {
+    const output = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+        output.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return output;
+}
+
+function isBlockedHost(hostname: string): boolean {
+    const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    if (host === 'localhost' || host.endsWith('.localhost')) return true;
+    if (host === 'metadata.google.internal') return true;
+
+    if (host.includes(':')) {
+        if (host === '::1' || host.startsWith('fe80:') || host.startsWith('fc') || host.startsWith('fd')) return true;
+        return false;
+    }
+
+    const parts = host.split('.').map(part => Number(part));
+    if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) {
+        return false;
+    }
+
+    const [a, b] = parts;
+    return (
+        a === 0 ||
+        a === 10 ||
+        a === 127 ||
+        (a === 169 && b === 254) ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168)
+    );
 }
 
 function extractSchemas(html: string): any[] {

--- a/src/ga4/client.ts
+++ b/src/ga4/client.ts
@@ -3,6 +3,8 @@ import { google } from 'googleapis';
 import { AccountConfig, loadConfig } from '../common/auth/config.js';
 import { resolveAccount } from '../common/auth/resolver.js';
 import { loadTokensForAccount, saveTokensForAccount, DEFAULT_CLIENT_ID, DEFAULT_CLIENT_SECRET } from '../google/client.js';
+import { getCurrentTenant } from '../tenant/context.js';
+import { assertAccountIdAllowed, assertGa4PropertyAllowed } from '../tenant/guard.js';
 
 export class GA4Client {
     private client: BetaAnalyticsDataClient;
@@ -55,12 +57,16 @@ export async function getGA4Client(propertyId?: string, accountId?: string): Pro
     const config = await loadConfig();
 
     if (accountId) {
+        const tenant = getCurrentTenant();
+        if (tenant) assertAccountIdAllowed(tenant, accountId, 'ga4');
         account = config.accounts[accountId];
         if (!account) throw new Error(`Account ${accountId} not found.`);
     } else {
         const accounts = Object.values(config.accounts).filter(a => a.engine === 'ga4');
 
         if (propertyId) {
+            const tenant = getCurrentTenant();
+            if (tenant) assertGa4PropertyAllowed(tenant, propertyId);
             // Try to find by propertyId property
             account = accounts.find(a => a.ga4PropertyId === propertyId);
 
@@ -76,6 +82,10 @@ export async function getGA4Client(propertyId?: string, accountId?: string): Pro
 
         // Default to single account if available and no specific account found yet
         if (!account) {
+            const tenant = getCurrentTenant();
+            if (tenant) {
+                throw new Error(`GA4 account for Property ID ${propertyId || 'default'} not found for tenant.`);
+            }
             if (accounts.length === 1) {
                 account = accounts[0];
             } else if (accounts.length > 1) {
@@ -152,6 +162,9 @@ export async function getGA4Client(propertyId?: string, accountId?: string): Pro
 
     // 4. Fallback to Environment Variables (Google Application Credentials)
     if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+        if (getCurrentTenant()) {
+            throw new Error(`Authentication configuration not found for account ${account.alias}. Tenant mode does not allow environment credential fallback.`);
+        }
         client = new BetaAnalyticsDataClient({
             keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS
         });

--- a/src/google/client.ts
+++ b/src/google/client.ts
@@ -3,6 +3,8 @@ import nodeMachineId from 'node-machine-id';
 import { AccountConfig, loadConfig, saveConfig, updateAccount, removeAccount } from '../common/auth/config.js';
 import { resolveAccount } from '../common/auth/resolver.js';
 import { logger } from '../utils/logger.js';
+import { getCurrentTenant } from '../tenant/context.js';
+import { assertAccountIdAllowed } from '../tenant/guard.js';
 const { machineIdSync } = nodeMachineId;
 
 const SCOPES = [
@@ -24,6 +26,8 @@ export async function getSearchConsoleClient(siteUrl?: string, accountId?: strin
   // 1. Resolve Account
   let account: AccountConfig;
   if (accountId) {
+    const tenant = getCurrentTenant();
+    if (tenant) assertAccountIdAllowed(tenant, accountId, 'google');
     const config = await loadConfig();
     account = config.accounts[accountId];
     if (!account) throw new Error(`Account ${accountId} not found.`);
@@ -84,6 +88,10 @@ export async function getSearchConsoleClient(siteUrl?: string, accountId?: strin
 
   // 4. Fallback to Service Account (Environment Variables) - Only if no specific account was resolved or it was a legacy fallback
   if (!accountId) {
+    if (getCurrentTenant()) {
+      throw new Error(`Authentication required for ${siteUrl || 'Google Search Console'}. Tenant mode does not allow environment credential fallback.`);
+    }
+
     if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
       const auth = new google.auth.GoogleAuth({
         scopes: SCOPES

--- a/src/google/tools/analytics.ts
+++ b/src/google/tools/analytics.ts
@@ -1,6 +1,7 @@
 import { getSearchConsoleClient } from '../client.js';
 import { searchconsole_v1 } from 'googleapis';
 import { logger } from '../../utils/logger.js';
+import { runGoogleApiCall } from '../upstream.js';
 
 const CACHE_TTL_MS = 60 * 1000; // 60 seconds
 const MAX_CACHE_SIZE = 100;
@@ -208,10 +209,12 @@ export async function queryAnalytics(options: AnalyticsOptions): Promise<searchc
         filters: options.filters?.length || 0
       });
 
-      const res = await client.searchanalytics.query({
-        siteUrl: options.siteUrl,
-        requestBody
-      });
+      const res = await runGoogleApiCall('searchanalytics.query', (requestOptions) =>
+        client.searchanalytics.query({
+          siteUrl: options.siteUrl,
+          requestBody
+        }, requestOptions)
+      );
 
       const rows = res.data.rows || [];
       logger.debug(`Received ${rows.length} rows for ${options.siteUrl}`);
@@ -229,7 +232,6 @@ export async function queryAnalytics(options: AnalyticsOptions): Promise<searchc
 
       return rows;
     } catch (error) {
-      logger.error(`Error fetching analytics for ${options.siteUrl}:`, (error as Error).message);
       analyticsCache.delete(cacheKey);
       throw error;
     }

--- a/src/google/tools/inspection-cache.ts
+++ b/src/google/tools/inspection-cache.ts
@@ -1,0 +1,255 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { searchconsole_v1 } from 'googleapis';
+import { sanitizeForLog } from '../../utils/redaction.js';
+import { TenantContext } from '../../tenant/types.js';
+
+export const INSPECTION_TOOL_VERSION = 'gsc-url-inspection-v1';
+const DEFAULT_TTL_HOURS = 24;
+
+export type InspectionCacheMode = 'read' | 'write' | 'read_write';
+
+export interface NormalizedInspectionResult {
+  inspectionUrl: string;
+  siteUrl: string;
+  verdict?: string;
+  coverageState?: string;
+  indexingState?: string;
+  lastCrawlTime?: string;
+  pageFetchState?: string;
+  robotsTxtState?: string;
+  googleCanonical?: string;
+  userCanonical?: string;
+  referringUrls: string[];
+  sitemap: string[];
+  inspectionResultLink?: string;
+  raw: searchconsole_v1.Schema$InspectUrlIndexResponse;
+}
+
+export interface InspectionCacheMetadata {
+  cacheHit: boolean;
+  apiCallMade: boolean;
+  quotaUnitEstimate: number;
+  cacheKey: string;
+  fetchedAt?: string;
+  expiresAt?: string;
+}
+
+export interface CachedInspectionEntry {
+  tenant_id: string;
+  siteUrl: string;
+  inspectionUrl: string;
+  tool_version: string;
+  raw?: searchconsole_v1.Schema$InspectUrlIndexResponse;
+  normalized?: NormalizedInspectionResult;
+  fetched_at: string;
+  expires_at: string;
+  api_status: 'ok' | 'error';
+  error_code?: string;
+  error_message?: string;
+}
+
+export interface InspectionResultWithMetadata extends NormalizedInspectionResult {
+  metadata: InspectionCacheMetadata;
+}
+
+export interface InspectionCacheEvent {
+  timestamp: string;
+  tenant_id: string;
+  siteUrl: string;
+  inspectionUrl?: string;
+  tool_version: string;
+  status: string;
+  cacheHit: boolean;
+  apiCallMade: boolean;
+  quotaUnitEstimate: number;
+  error_code?: string;
+}
+
+export interface InspectionCacheStats {
+  tenantId: string;
+  siteUrl?: string;
+  startDate?: string;
+  endDate?: string;
+  totalRequests: number;
+  cacheHits: number;
+  apiCalls: number;
+  errors: number;
+  quotaUnitEstimate: number;
+}
+
+export function normalizeInspectionResponse(
+  siteUrl: string,
+  inspectionUrl: string,
+  raw: searchconsole_v1.Schema$InspectUrlIndexResponse
+): NormalizedInspectionResult {
+  const inspectionResult = raw.inspectionResult || {};
+  const indexStatus = inspectionResult.indexStatusResult || {};
+
+  return {
+    inspectionUrl,
+    siteUrl,
+    verdict: indexStatus.verdict || undefined,
+    coverageState: indexStatus.coverageState || undefined,
+    indexingState: indexStatus.indexingState || undefined,
+    lastCrawlTime: indexStatus.lastCrawlTime || undefined,
+    pageFetchState: indexStatus.pageFetchState || undefined,
+    robotsTxtState: indexStatus.robotsTxtState || undefined,
+    googleCanonical: indexStatus.googleCanonical || undefined,
+    userCanonical: indexStatus.userCanonical || undefined,
+    referringUrls: Array.isArray(indexStatus.referringUrls) ? indexStatus.referringUrls : [],
+    sitemap: Array.isArray(indexStatus.sitemap) ? indexStatus.sitemap : [],
+    inspectionResultLink: inspectionResult.inspectionResultLink || undefined,
+    raw
+  };
+}
+
+export function createInspectionCacheKey(tenantId: string, siteUrl: string, inspectionUrl: string) {
+  return `${tenantId}:${siteUrl}:${inspectionUrl}:${INSPECTION_TOOL_VERSION}`;
+}
+
+export function createInspectionCacheHash(cacheKey: string) {
+  return createHash('sha256').update(cacheKey).digest('hex');
+}
+
+export function getInspectionCacheDir() {
+  return process.env.MCP_INSPECTION_CACHE_DIR || join(homedir(), '.search-console-mcp-inspection-cache');
+}
+
+export function resetInspectionCacheForTests() {
+  // Cache storage is file-backed only; this helper exists for a stable test import surface.
+}
+
+export function readFreshInspectionCache(
+  tenantId: string,
+  siteUrl: string,
+  inspectionUrl: string,
+  maxAgeHours = DEFAULT_TTL_HOURS
+): { entry: CachedInspectionEntry; cacheKey: string } | undefined {
+  const cacheKey = createInspectionCacheKey(tenantId, siteUrl, inspectionUrl);
+  const path = entryPath(cacheKey);
+  if (!existsSync(path)) return undefined;
+
+  const entry = JSON.parse(readFileSync(path, 'utf8')) as CachedInspectionEntry;
+  const now = Date.now();
+  const fetchedAt = Date.parse(entry.fetched_at);
+  const expiresAt = Date.parse(entry.expires_at);
+  const maxAgeMs = Math.max(0, maxAgeHours) * 60 * 60 * 1000;
+  const freshByAge = Number.isFinite(fetchedAt) && now - fetchedAt <= maxAgeMs;
+  const freshByExpiry = Number.isFinite(expiresAt) && now <= expiresAt;
+
+  if (entry.api_status === 'ok' && entry.normalized && freshByAge && freshByExpiry) {
+    return { entry, cacheKey };
+  }
+
+  return undefined;
+}
+
+export function writeInspectionCacheEntry(
+  tenantId: string,
+  siteUrl: string,
+  inspectionUrl: string,
+  raw: searchconsole_v1.Schema$InspectUrlIndexResponse | undefined,
+  normalized: NormalizedInspectionResult | undefined,
+  options: { ttlHours?: number; apiStatus: 'ok' | 'error'; errorCode?: string; errorMessage?: string }
+): CachedInspectionEntry {
+  ensureCacheDirs();
+  const fetchedAt = new Date();
+  const ttlHours = options.ttlHours ?? DEFAULT_TTL_HOURS;
+  const expiresAt = new Date(fetchedAt.getTime() + ttlHours * 60 * 60 * 1000);
+  const entry: CachedInspectionEntry = {
+    tenant_id: tenantId,
+    siteUrl,
+    inspectionUrl,
+    tool_version: INSPECTION_TOOL_VERSION,
+    raw,
+    normalized,
+    fetched_at: fetchedAt.toISOString(),
+    expires_at: expiresAt.toISOString(),
+    api_status: options.apiStatus,
+    error_code: options.errorCode,
+    error_message: options.errorMessage ? sanitizeForLog(options.errorMessage) : undefined
+  };
+  writeFileSync(entryPath(createInspectionCacheKey(tenantId, siteUrl, inspectionUrl)), `${JSON.stringify(entry, null, 2)}\n`, { mode: 0o600 });
+  return entry;
+}
+
+export function appendInspectionCacheEvent(event: InspectionCacheEvent) {
+  ensureCacheDirs();
+  appendFileSync(eventsPath(), `${JSON.stringify({
+    ...event,
+    error_code: event.error_code ? sanitizeForLog(event.error_code) : undefined
+  })}\n`, { mode: 0o600 });
+}
+
+export function getInspectionCacheStats(
+  tenant: TenantContext,
+  input: { siteUrl?: string; startDate?: string; endDate?: string }
+): InspectionCacheStats {
+  const stats: InspectionCacheStats = {
+    tenantId: tenant.tenantId,
+    siteUrl: input.siteUrl,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    totalRequests: 0,
+    cacheHits: 0,
+    apiCalls: 0,
+    errors: 0,
+    quotaUnitEstimate: 0
+  };
+
+  const path = eventsPath();
+  if (!existsSync(path)) return stats;
+
+  const start = input.startDate ? Date.parse(`${input.startDate}T00:00:00.000Z`) : undefined;
+  const end = input.endDate ? Date.parse(`${input.endDate}T23:59:59.999Z`) : undefined;
+  const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean);
+
+  for (const line of lines) {
+    let event: InspectionCacheEvent;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (event.tenant_id !== tenant.tenantId) continue;
+    if (input.siteUrl && event.siteUrl !== input.siteUrl) continue;
+
+    const timestamp = Date.parse(event.timestamp);
+    if (start !== undefined && timestamp < start) continue;
+    if (end !== undefined && timestamp > end) continue;
+
+    stats.totalRequests++;
+    if (event.cacheHit) stats.cacheHits++;
+    if (event.apiCallMade) stats.apiCalls++;
+    if (event.status === 'error' || event.status === 'quota_limited') stats.errors++;
+    stats.quotaUnitEstimate += event.quotaUnitEstimate || 0;
+  }
+
+  return stats;
+}
+
+export function listInspectionCacheFiles() {
+  const dir = entriesDir();
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter(file => file.endsWith('.json')).map(file => join(dir, file));
+}
+
+function entryPath(cacheKey: string) {
+  return join(entriesDir(), `${createInspectionCacheHash(cacheKey)}.json`);
+}
+
+function entriesDir() {
+  return join(getInspectionCacheDir(), 'entries');
+}
+
+function eventsPath() {
+  return join(getInspectionCacheDir(), 'events.jsonl');
+}
+
+function ensureCacheDirs() {
+  mkdirSync(entriesDir(), { recursive: true, mode: 0o700 });
+}

--- a/src/google/tools/inspection-cache.ts
+++ b/src/google/tools/inspection-cache.ts
@@ -9,9 +9,10 @@ import { TenantContext } from '../../tenant/types.js';
 export const INSPECTION_TOOL_VERSION = 'gsc-url-inspection-v1';
 const DEFAULT_TTL_HOURS = 24;
 
-export type InspectionCacheMode = 'read' | 'write' | 'read_write';
+export type InspectionCacheMode = 'read_write' | 'read_only' | 'bypass' | 'read' | 'write';
 
 export interface NormalizedInspectionResult {
+  url: string;
   inspectionUrl: string;
   siteUrl: string;
   verdict?: string;
@@ -33,8 +34,10 @@ export interface InspectionCacheMetadata {
   apiCallMade: boolean;
   quotaUnitEstimate: number;
   cacheKey: string;
+  cachedAt?: string;
   fetchedAt?: string;
   expiresAt?: string;
+  cacheAgeHours?: number;
 }
 
 export interface CachedInspectionEntry {
@@ -89,6 +92,7 @@ export function normalizeInspectionResponse(
   const indexStatus = inspectionResult.indexStatusResult || {};
 
   return {
+    url: normalizeInspectionUrlForCache(inspectionUrl),
     inspectionUrl,
     siteUrl,
     verdict: indexStatus.verdict || undefined,
@@ -107,7 +111,7 @@ export function normalizeInspectionResponse(
 }
 
 export function createInspectionCacheKey(tenantId: string, siteUrl: string, inspectionUrl: string) {
-  return `${tenantId}:${siteUrl}:${inspectionUrl}:${INSPECTION_TOOL_VERSION}`;
+  return `${tenantId}:${siteUrl}:${normalizeInspectionUrlForCache(inspectionUrl)}:${INSPECTION_TOOL_VERSION}`;
 }
 
 export function createInspectionCacheHash(cacheKey: string) {
@@ -145,6 +149,25 @@ export function readFreshInspectionCache(
   }
 
   return undefined;
+}
+
+export function normalizeInspectionUrlForCache(inspectionUrl: string) {
+  try {
+    const parsed = new URL(inspectionUrl);
+    parsed.protocol = parsed.protocol.toLowerCase();
+    parsed.hostname = parsed.hostname.toLowerCase();
+    parsed.hash = '';
+    return parsed.href;
+  } catch {
+    return inspectionUrl.trim();
+  }
+}
+
+export function calculateCacheAgeHours(cachedAt?: string, now = Date.now()) {
+  if (!cachedAt) return undefined;
+  const cachedAtMs = Date.parse(cachedAt);
+  if (!Number.isFinite(cachedAtMs)) return undefined;
+  return Math.max(0, (now - cachedAtMs) / (60 * 60 * 1000));
 }
 
 export function writeInspectionCacheEntry(
@@ -225,7 +248,7 @@ export function getInspectionCacheStats(
     stats.totalRequests++;
     if (event.cacheHit) stats.cacheHits++;
     if (event.apiCallMade) stats.apiCalls++;
-    if (event.status === 'error' || event.status === 'quota_limited') stats.errors++;
+    if (['error', 'provider_error', 'quota_limited', 'forbidden_url', 'invalid_url'].includes(event.status)) stats.errors++;
     stats.quotaUnitEstimate += event.quotaUnitEstimate || 0;
   }
 

--- a/src/google/tools/inspection-jobs.ts
+++ b/src/google/tools/inspection-jobs.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { sanitizeForLog } from '../../utils/redaction.js';
 import { forbidden, notFound } from '../../tenant/errors.js';
 import { TenantContext } from '../../tenant/types.js';
+import { assertGoogleSiteAllowed } from '../../tenant/guard.js';
 import { getInspectionCacheDir, InspectionCacheMode } from './inspection-cache.js';
 import { inspectBatchWithCache } from './inspection.js';
 
@@ -18,6 +19,7 @@ export interface InspectionBatchJob {
   updatedAt: string;
   startedAt?: string;
   completedAt?: string;
+  expiresAt: string;
   requestedUrls: number;
   processedUrls: number;
   cacheMode: InspectionCacheMode;
@@ -64,9 +66,16 @@ export interface StartInspectionBatchJobInput {
 
 const DEFAULT_MAX_AGE_HOURS = 24;
 const DEFAULT_CACHE_MODE: InspectionCacheMode = 'read_write';
+const DEFAULT_JOB_RETENTION_HOURS = 24;
+const DEFAULT_RESULTS_LIMIT = 100;
+const DEFAULT_MAX_RESULTS_LIMIT = 1000;
 
 export function startInspectionBatchJob(input: StartInspectionBatchJobInput) {
+  cleanupExpiredInspectionJobs();
+  assertGoogleSiteAllowed(input.tenant, input.siteUrl);
+
   const now = new Date().toISOString();
+  const expiresAt = new Date(Date.parse(now) + jobRetentionHours() * 60 * 60 * 1000).toISOString();
   const job: InspectionBatchJob = {
     jobId: randomUUID(),
     tenantId: input.tenant.tenantId,
@@ -74,6 +83,7 @@ export function startInspectionBatchJob(input: StartInspectionBatchJobInput) {
     status: 'queued',
     createdAt: now,
     updatedAt: now,
+    expiresAt,
     requestedUrls: input.urls.length,
     processedUrls: 0,
     cacheMode: input.cacheMode || DEFAULT_CACHE_MODE,
@@ -95,7 +105,7 @@ export function startInspectionBatchJob(input: StartInspectionBatchJobInput) {
     results: []
   });
 
-  void runJobSoon(job.jobId, input.tenant);
+  void runJobSoon(job.jobId, tenantForWorker(input.tenant));
 
   return {
     jobId: job.jobId,
@@ -106,11 +116,13 @@ export function startInspectionBatchJob(input: StartInspectionBatchJobInput) {
     maxApiCallsPerRun: job.maxApiCallsPerRun,
     cacheMode: job.cacheMode,
     maxAgeHours: job.maxAgeHours,
-    createdAt: job.createdAt
+    createdAt: job.createdAt,
+    expiresAt: job.expiresAt
   };
 }
 
 export function getInspectionBatchJobStatus(tenant: TenantContext, jobId: string) {
+  cleanupExpiredInspectionJobs();
   const job = readAuthorizedJob(tenant, jobId);
   return {
     jobId: job.jobId,
@@ -121,6 +133,7 @@ export function getInspectionBatchJobStatus(tenant: TenantContext, jobId: string
     updatedAt: job.updatedAt,
     startedAt: job.startedAt,
     completedAt: job.completedAt,
+    expiresAt: job.expiresAt,
     requestedUrls: job.requestedUrls,
     processedUrls: job.processedUrls,
     cacheMode: job.cacheMode,
@@ -138,10 +151,11 @@ export function getInspectionBatchJobResults(
   jobId: string,
   options: { offset?: number; limit?: number } = {}
 ) {
+  cleanupExpiredInspectionJobs();
   const job = readAuthorizedJob(tenant, jobId);
   const stored = readJobResults(jobId);
   const offset = Math.max(0, options.offset ?? 0);
-  const limit = options.limit === undefined ? stored.results.length : Math.max(0, options.limit);
+  const limit = normalizeResultsLimit(options.limit);
   const results = stored.results.slice(offset, offset + limit);
   return {
     jobId: job.jobId,
@@ -153,13 +167,15 @@ export function getInspectionBatchJobResults(
       offset,
       limit,
       returned: results.length,
-      total: stored.results.length
+      total: stored.results.length,
+      hasMore: offset + results.length < stored.results.length
     },
     results
   };
 }
 
 export function cancelInspectionBatchJob(tenant: TenantContext, jobId: string) {
+  cleanupExpiredInspectionJobs();
   const job = readAuthorizedJob(tenant, jobId);
   if (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') {
     return {
@@ -309,6 +325,26 @@ function writeJobResults(results: InspectionBatchJobResults) {
   writeFileSync(resultsPath(results.jobId), `${JSON.stringify(results, null, 2)}\n`, { mode: 0o600 });
 }
 
+export function cleanupExpiredInspectionJobs(now = Date.now()) {
+  const dir = jobsDir();
+  if (!existsSync(dir)) return;
+
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.json') || file.endsWith('.input.json') || file.endsWith('.results.json')) continue;
+    const jobId = file.slice(0, -'.json'.length);
+    try {
+      const job = readJob(jobId);
+      if (!isTerminalJob(job)) continue;
+      const expiresAt = Date.parse(job.expiresAt || '');
+      if (Number.isFinite(expiresAt) && now >= expiresAt) {
+        deleteJobFiles(job.jobId);
+      }
+    } catch {
+      continue;
+    }
+  }
+}
+
 function jobPath(jobId: string) {
   return join(jobsDir(), `${safeJobId(jobId)}.json`);
 }
@@ -329,6 +365,16 @@ function ensureJobDir() {
   mkdirSync(jobsDir(), { recursive: true, mode: 0o700 });
 }
 
+function deleteJobFiles(jobId: string) {
+  for (const path of [jobPath(jobId), inputPath(jobId), resultsPath(jobId)]) {
+    try {
+      if (existsSync(path)) unlinkSync(path);
+    } catch {
+      // Best-effort cleanup should never affect active tool calls.
+    }
+  }
+}
+
 function safeJobId(jobId: string) {
   if (!/^[a-zA-Z0-9_-]+$/.test(jobId)) {
     throw notFound('404 Not Found: inspection batch job was not found');
@@ -347,6 +393,28 @@ function emptySummary(requested: number): InspectionBatchJobSummary {
     forbiddenUrls: 0,
     quotaLimited: 0,
     quotaUnitEstimate: 0
+  };
+}
+
+function normalizeResultsLimit(limit?: number) {
+  const maxLimit = Math.max(1, Number(process.env.MCP_INSPECTION_JOB_MAX_RESULTS_LIMIT || DEFAULT_MAX_RESULTS_LIMIT));
+  const requested = limit === undefined ? DEFAULT_RESULTS_LIMIT : Math.max(0, Math.floor(limit));
+  return Math.min(requested, maxLimit);
+}
+
+function jobRetentionHours() {
+  const configured = Number(process.env.MCP_INSPECTION_JOB_RETENTION_HOURS || DEFAULT_JOB_RETENTION_HOURS);
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_JOB_RETENTION_HOURS;
+}
+
+function isTerminalJob(job: InspectionBatchJob) {
+  return job.status === 'completed' || job.status === 'cancelled' || job.status === 'failed';
+}
+
+function tenantForWorker(tenant: TenantContext): TenantContext {
+  return {
+    ...tenant,
+    indexNowKeys: {}
   };
 }
 

--- a/src/google/tools/inspection-jobs.ts
+++ b/src/google/tools/inspection-jobs.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { sanitizeForLog } from '../../utils/redaction.js';
 import { forbidden, notFound } from '../../tenant/errors.js';
@@ -104,6 +104,7 @@ export function startInspectionBatchJob(input: StartInspectionBatchJobInput) {
     summary: job.summary,
     results: []
   });
+  writeFileSync(resultsItemsPath(job.jobId), '', { mode: 0o600 });
 
   void runJobSoon(job.jobId, tenantForWorker(input.tenant));
 
@@ -153,10 +154,9 @@ export function getInspectionBatchJobResults(
 ) {
   cleanupExpiredInspectionJobs();
   const job = readAuthorizedJob(tenant, jobId);
-  const stored = readJobResults(jobId);
   const offset = Math.max(0, options.offset ?? 0);
   const limit = normalizeResultsLimit(options.limit);
-  const results = stored.results.slice(offset, offset + limit);
+  const page = readJobResultSlice(jobId, offset, limit);
   return {
     jobId: job.jobId,
     tenantId: job.tenantId,
@@ -166,11 +166,11 @@ export function getInspectionBatchJobResults(
     pagination: {
       offset,
       limit,
-      returned: results.length,
-      total: stored.results.length,
-      hasMore: offset + results.length < stored.results.length
+      returned: page.results.length,
+      total: page.total,
+      hasMore: offset + page.results.length < page.total
     },
-    results
+    results: page.results
   };
 }
 
@@ -211,12 +211,12 @@ async function runInspectionBatchJob(jobId: string, tenant: TenantContext) {
   if (job.status === 'cancelled' || job.cancelRequested) return;
 
   const urls = readJobInput(jobId);
-  const results = readJobResults(jobId);
   const now = new Date().toISOString();
   job.status = 'running';
   job.startedAt = job.startedAt || now;
   job.updatedAt = now;
   writeJob(job);
+  writeJobResultsFromJob(job);
 
   const chunkSize = Number(process.env.MCP_INSPECTION_JOB_CHUNK_SIZE || process.env.MCP_INSPECTION_CHUNK_SIZE || 25);
   for (const chunk of chunkArray(urls, chunkSize)) {
@@ -226,8 +226,7 @@ async function runInspectionBatchJob(jobId: string, tenant: TenantContext) {
       job.completedAt = new Date().toISOString();
       job.updatedAt = job.completedAt;
       writeJob(job);
-      results.status = job.status;
-      writeJobResults(results);
+      writeJobResultsFromJob(job);
       return;
     }
 
@@ -240,23 +239,19 @@ async function runInspectionBatchJob(jobId: string, tenant: TenantContext) {
       maxApiCallsPerRun: remainingApiCalls
     });
 
-    results.results.push(...batch.results);
+    appendJobResultRows(jobId, batch.results);
     mergeSummary(job.summary, batch.summary);
-    job.processedUrls = results.results.length;
+    job.processedUrls += batch.results.length;
     job.updatedAt = new Date().toISOString();
-    results.status = job.status;
-    results.summary = job.summary;
     writeJob(job);
-    writeJobResults(results);
+    writeJobResultsFromJob(job);
   }
 
   job.status = 'completed';
   job.completedAt = new Date().toISOString();
   job.updatedAt = job.completedAt;
-  results.status = job.status;
-  results.summary = job.summary;
   writeJob(job);
-  writeJobResults(results);
+  writeJobResultsFromJob(job);
 }
 
 function failJob(jobId: string, error: unknown) {
@@ -267,10 +262,7 @@ function failJob(jobId: string, error: unknown) {
     job.completedAt = new Date().toISOString();
     job.updatedAt = job.completedAt;
     writeJob(job);
-    const results = readJobResults(jobId);
-    results.status = 'failed';
-    results.summary = job.summary;
-    writeJobResults(results);
+    writeJobResultsFromJob(job);
   } catch {
     // Nothing useful to do if the job files disappeared while the worker was failing.
   }
@@ -325,6 +317,66 @@ function writeJobResults(results: InspectionBatchJobResults) {
   writeFileSync(resultsPath(results.jobId), `${JSON.stringify(results, null, 2)}\n`, { mode: 0o600 });
 }
 
+function writeJobResultsFromJob(job: InspectionBatchJob) {
+  writeJobResults({
+    jobId: job.jobId,
+    tenantId: job.tenantId,
+    siteUrl: job.siteUrl,
+    status: job.status,
+    summary: job.summary,
+    results: []
+  });
+}
+
+function appendJobResultRows(jobId: string, rows: any[]) {
+  if (rows.length === 0) return;
+  ensureJobDir();
+  const payload = rows.map(row => JSON.stringify(row)).join('\n');
+  appendFileSync(resultsItemsPath(jobId), `${payload}\n`, { mode: 0o600 });
+}
+
+function readJobResultSlice(jobId: string, offset: number, limit: number): { results: any[]; total: number } {
+  const itemsPath = resultsItemsPath(jobId);
+  if (!existsSync(itemsPath)) {
+    const stored = readJobResults(jobId);
+    return {
+      results: stored.results.slice(offset, offset + limit),
+      total: stored.results.length
+    };
+  }
+
+  const results: any[] = [];
+  let total = 0;
+  let carry = '';
+  const fd = openSync(itemsPath, 'r');
+  const buffer = Buffer.alloc(64 * 1024);
+  try {
+    while (true) {
+      const bytesRead = readSync(fd, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      const text = carry + buffer.toString('utf8', 0, bytesRead);
+      const lines = text.split('\n');
+      carry = lines.pop() || '';
+      for (const line of lines) {
+        if (!line) continue;
+        if (total >= offset && results.length < limit) {
+          results.push(JSON.parse(line));
+        }
+        total++;
+      }
+    }
+    if (carry) {
+      if (total >= offset && results.length < limit) {
+        results.push(JSON.parse(carry));
+      }
+      total++;
+    }
+  } finally {
+    closeSync(fd);
+  }
+  return { results, total };
+}
+
 export function cleanupExpiredInspectionJobs(now = Date.now()) {
   const dir = jobsDir();
   if (!existsSync(dir)) return;
@@ -357,6 +409,10 @@ function resultsPath(jobId: string) {
   return join(jobsDir(), `${safeJobId(jobId)}.results.json`);
 }
 
+function resultsItemsPath(jobId: string) {
+  return join(jobsDir(), `${safeJobId(jobId)}.results.jsonl`);
+}
+
 function jobsDir() {
   return join(getInspectionCacheDir(), 'jobs');
 }
@@ -366,7 +422,7 @@ function ensureJobDir() {
 }
 
 function deleteJobFiles(jobId: string) {
-  for (const path of [jobPath(jobId), inputPath(jobId), resultsPath(jobId)]) {
+  for (const path of [jobPath(jobId), inputPath(jobId), resultsPath(jobId), resultsItemsPath(jobId)]) {
     try {
       if (existsSync(path)) unlinkSync(path);
     } catch {

--- a/src/google/tools/inspection-jobs.ts
+++ b/src/google/tools/inspection-jobs.ts
@@ -1,0 +1,371 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { sanitizeForLog } from '../../utils/redaction.js';
+import { forbidden, notFound } from '../../tenant/errors.js';
+import { TenantContext } from '../../tenant/types.js';
+import { getInspectionCacheDir, InspectionCacheMode } from './inspection-cache.js';
+import { inspectBatchWithCache } from './inspection.js';
+
+export type InspectionBatchJobStatus = 'queued' | 'running' | 'completed' | 'cancelled' | 'failed';
+
+export interface InspectionBatchJob {
+  jobId: string;
+  tenantId: string;
+  siteUrl: string;
+  status: InspectionBatchJobStatus;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  requestedUrls: number;
+  processedUrls: number;
+  cacheMode: InspectionCacheMode;
+  maxAgeHours: number;
+  forceRefresh: boolean;
+  maxApiCallsPerRun: number;
+  languageCode?: string;
+  cancelRequested?: boolean;
+  errorMessage?: string;
+  summary: InspectionBatchJobSummary;
+}
+
+export interface InspectionBatchJobSummary {
+  requested: number;
+  returned: number;
+  cacheHits: number;
+  apiCallsMade: number;
+  errors: number;
+  invalidUrls: number;
+  forbiddenUrls: number;
+  quotaLimited: number;
+  quotaUnitEstimate: number;
+}
+
+export interface InspectionBatchJobResults {
+  jobId: string;
+  tenantId: string;
+  siteUrl: string;
+  status: InspectionBatchJobStatus;
+  summary: InspectionBatchJobSummary;
+  results: any[];
+}
+
+export interface StartInspectionBatchJobInput {
+  siteUrl: string;
+  urls: string[];
+  tenant: TenantContext;
+  cacheMode?: InspectionCacheMode;
+  maxAgeHours?: number;
+  forceRefresh?: boolean;
+  languageCode?: string;
+  maxApiCallsPerRun?: number;
+}
+
+const DEFAULT_MAX_AGE_HOURS = 24;
+const DEFAULT_CACHE_MODE: InspectionCacheMode = 'read_write';
+
+export function startInspectionBatchJob(input: StartInspectionBatchJobInput) {
+  const now = new Date().toISOString();
+  const job: InspectionBatchJob = {
+    jobId: randomUUID(),
+    tenantId: input.tenant.tenantId,
+    siteUrl: input.siteUrl,
+    status: 'queued',
+    createdAt: now,
+    updatedAt: now,
+    requestedUrls: input.urls.length,
+    processedUrls: 0,
+    cacheMode: input.cacheMode || DEFAULT_CACHE_MODE,
+    maxAgeHours: input.maxAgeHours ?? DEFAULT_MAX_AGE_HOURS,
+    forceRefresh: input.forceRefresh === true,
+    maxApiCallsPerRun: input.maxApiCallsPerRun ?? input.tenant.limits.maxBatchUrls ?? 10,
+    languageCode: input.languageCode,
+    summary: emptySummary(input.urls.length)
+  };
+
+  writeJob(job);
+  writeJobInput(job.jobId, input.urls);
+  writeJobResults({
+    jobId: job.jobId,
+    tenantId: job.tenantId,
+    siteUrl: job.siteUrl,
+    status: job.status,
+    summary: job.summary,
+    results: []
+  });
+
+  void runJobSoon(job.jobId, input.tenant);
+
+  return {
+    jobId: job.jobId,
+    status: job.status,
+    tenantId: job.tenantId,
+    siteUrl: job.siteUrl,
+    requestedUrls: job.requestedUrls,
+    maxApiCallsPerRun: job.maxApiCallsPerRun,
+    cacheMode: job.cacheMode,
+    maxAgeHours: job.maxAgeHours,
+    createdAt: job.createdAt
+  };
+}
+
+export function getInspectionBatchJobStatus(tenant: TenantContext, jobId: string) {
+  const job = readAuthorizedJob(tenant, jobId);
+  return {
+    jobId: job.jobId,
+    tenantId: job.tenantId,
+    siteUrl: job.siteUrl,
+    status: job.status,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+    startedAt: job.startedAt,
+    completedAt: job.completedAt,
+    requestedUrls: job.requestedUrls,
+    processedUrls: job.processedUrls,
+    cacheMode: job.cacheMode,
+    maxAgeHours: job.maxAgeHours,
+    forceRefresh: job.forceRefresh,
+    maxApiCallsPerRun: job.maxApiCallsPerRun,
+    cancelRequested: job.cancelRequested === true,
+    errorMessage: job.errorMessage,
+    summary: job.summary
+  };
+}
+
+export function getInspectionBatchJobResults(
+  tenant: TenantContext,
+  jobId: string,
+  options: { offset?: number; limit?: number } = {}
+) {
+  const job = readAuthorizedJob(tenant, jobId);
+  const stored = readJobResults(jobId);
+  const offset = Math.max(0, options.offset ?? 0);
+  const limit = options.limit === undefined ? stored.results.length : Math.max(0, options.limit);
+  const results = stored.results.slice(offset, offset + limit);
+  return {
+    jobId: job.jobId,
+    tenantId: job.tenantId,
+    siteUrl: job.siteUrl,
+    status: job.status,
+    summary: job.summary,
+    pagination: {
+      offset,
+      limit,
+      returned: results.length,
+      total: stored.results.length
+    },
+    results
+  };
+}
+
+export function cancelInspectionBatchJob(tenant: TenantContext, jobId: string) {
+  const job = readAuthorizedJob(tenant, jobId);
+  if (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') {
+    return {
+      jobId: job.jobId,
+      status: job.status,
+      cancelAccepted: false
+    };
+  }
+
+  const now = new Date().toISOString();
+  job.cancelRequested = true;
+  if (job.status === 'queued') {
+    job.status = 'cancelled';
+    job.completedAt = now;
+  }
+  job.updatedAt = now;
+  writeJob(job);
+  return {
+    jobId: job.jobId,
+    status: job.status,
+    cancelAccepted: true
+  };
+}
+
+async function runJobSoon(jobId: string, tenant: TenantContext) {
+  setTimeout(() => {
+    runInspectionBatchJob(jobId, tenant).catch(error => failJob(jobId, error));
+  }, 0);
+}
+
+async function runInspectionBatchJob(jobId: string, tenant: TenantContext) {
+  let job = readJob(jobId);
+  if (job.status === 'cancelled' || job.cancelRequested) return;
+
+  const urls = readJobInput(jobId);
+  const results = readJobResults(jobId);
+  const now = new Date().toISOString();
+  job.status = 'running';
+  job.startedAt = job.startedAt || now;
+  job.updatedAt = now;
+  writeJob(job);
+
+  const chunkSize = Number(process.env.MCP_INSPECTION_JOB_CHUNK_SIZE || process.env.MCP_INSPECTION_CHUNK_SIZE || 25);
+  for (const chunk of chunkArray(urls, chunkSize)) {
+    job = readJob(jobId);
+    if (job.cancelRequested || job.status === 'cancelled') {
+      job.status = 'cancelled';
+      job.completedAt = new Date().toISOString();
+      job.updatedAt = job.completedAt;
+      writeJob(job);
+      results.status = job.status;
+      writeJobResults(results);
+      return;
+    }
+
+    const remainingApiCalls = Math.max(0, job.maxApiCallsPerRun - job.summary.apiCallsMade);
+    const batch = await inspectBatchWithCache(job.siteUrl, chunk, tenant, {
+      cacheMode: job.cacheMode,
+      maxAgeHours: job.maxAgeHours,
+      forceRefresh: job.forceRefresh,
+      languageCode: job.languageCode,
+      maxApiCallsPerRun: remainingApiCalls
+    });
+
+    results.results.push(...batch.results);
+    mergeSummary(job.summary, batch.summary);
+    job.processedUrls = results.results.length;
+    job.updatedAt = new Date().toISOString();
+    results.status = job.status;
+    results.summary = job.summary;
+    writeJob(job);
+    writeJobResults(results);
+  }
+
+  job.status = 'completed';
+  job.completedAt = new Date().toISOString();
+  job.updatedAt = job.completedAt;
+  results.status = job.status;
+  results.summary = job.summary;
+  writeJob(job);
+  writeJobResults(results);
+}
+
+function failJob(jobId: string, error: unknown) {
+  try {
+    const job = readJob(jobId);
+    job.status = 'failed';
+    job.errorMessage = sanitizeForLog((error as Error).message || 'Inspection batch job failed');
+    job.completedAt = new Date().toISOString();
+    job.updatedAt = job.completedAt;
+    writeJob(job);
+    const results = readJobResults(jobId);
+    results.status = 'failed';
+    results.summary = job.summary;
+    writeJobResults(results);
+  } catch {
+    // Nothing useful to do if the job files disappeared while the worker was failing.
+  }
+}
+
+function readAuthorizedJob(tenant: TenantContext, jobId: string) {
+  const job = readJob(jobId);
+  if (job.tenantId !== tenant.tenantId) {
+    throw forbidden('403 Forbidden: job is not allowed for this tenant');
+  }
+  return job;
+}
+
+function readJob(jobId: string): InspectionBatchJob {
+  const path = jobPath(jobId);
+  if (!existsSync(path)) throw notFound('404 Not Found: inspection batch job was not found');
+  return JSON.parse(readFileSync(path, 'utf8')) as InspectionBatchJob;
+}
+
+function writeJob(job: InspectionBatchJob) {
+  ensureJobDir();
+  writeFileSync(jobPath(job.jobId), `${JSON.stringify(job, null, 2)}\n`, { mode: 0o600 });
+}
+
+function readJobInput(jobId: string): string[] {
+  return JSON.parse(readFileSync(inputPath(jobId), 'utf8')) as string[];
+}
+
+function writeJobInput(jobId: string, urls: string[]) {
+  ensureJobDir();
+  writeFileSync(inputPath(jobId), `${JSON.stringify(urls)}\n`, { mode: 0o600 });
+}
+
+function readJobResults(jobId: string): InspectionBatchJobResults {
+  const path = resultsPath(jobId);
+  if (!existsSync(path)) {
+    const job = readJob(jobId);
+    return {
+      jobId: job.jobId,
+      tenantId: job.tenantId,
+      siteUrl: job.siteUrl,
+      status: job.status,
+      summary: job.summary,
+      results: []
+    };
+  }
+  return JSON.parse(readFileSync(path, 'utf8')) as InspectionBatchJobResults;
+}
+
+function writeJobResults(results: InspectionBatchJobResults) {
+  ensureJobDir();
+  writeFileSync(resultsPath(results.jobId), `${JSON.stringify(results, null, 2)}\n`, { mode: 0o600 });
+}
+
+function jobPath(jobId: string) {
+  return join(jobsDir(), `${safeJobId(jobId)}.json`);
+}
+
+function inputPath(jobId: string) {
+  return join(jobsDir(), `${safeJobId(jobId)}.input.json`);
+}
+
+function resultsPath(jobId: string) {
+  return join(jobsDir(), `${safeJobId(jobId)}.results.json`);
+}
+
+function jobsDir() {
+  return join(getInspectionCacheDir(), 'jobs');
+}
+
+function ensureJobDir() {
+  mkdirSync(jobsDir(), { recursive: true, mode: 0o700 });
+}
+
+function safeJobId(jobId: string) {
+  if (!/^[a-zA-Z0-9_-]+$/.test(jobId)) {
+    throw notFound('404 Not Found: inspection batch job was not found');
+  }
+  return jobId;
+}
+
+function emptySummary(requested: number): InspectionBatchJobSummary {
+  return {
+    requested,
+    returned: 0,
+    cacheHits: 0,
+    apiCallsMade: 0,
+    errors: 0,
+    invalidUrls: 0,
+    forbiddenUrls: 0,
+    quotaLimited: 0,
+    quotaUnitEstimate: 0
+  };
+}
+
+function mergeSummary(target: InspectionBatchJobSummary, source: InspectionBatchJobSummary) {
+  target.returned += source.returned;
+  target.cacheHits += source.cacheHits;
+  target.apiCallsMade += source.apiCallsMade;
+  target.errors += source.errors;
+  target.invalidUrls += source.invalidUrls;
+  target.forbiddenUrls += source.forbiddenUrls;
+  target.quotaLimited += source.quotaLimited;
+  target.quotaUnitEstimate += source.quotaUnitEstimate;
+}
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunkSize = Math.max(1, Math.floor(size));
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize));
+  }
+  return chunks;
+}

--- a/src/google/tools/inspection.ts
+++ b/src/google/tools/inspection.ts
@@ -2,19 +2,23 @@ import { getSearchConsoleClient } from '../client.js';
 import { searchconsole_v1 } from 'googleapis';
 import { limitConcurrency } from '../../common/concurrency.js';
 import { TenantContext } from '../../tenant/types.js';
+import { isUrlAllowedBySites } from '../../tenant/guard.js';
 import { sanitizeForLog } from '../../utils/redaction.js';
 import {
   appendInspectionCacheEvent,
+  calculateCacheAgeHours,
   InspectionCacheMetadata,
   InspectionCacheMode,
   InspectionResultWithMetadata,
   normalizeInspectionResponse,
+  normalizeInspectionUrlForCache,
   readFreshInspectionCache,
   writeInspectionCacheEntry,
   createInspectionCacheKey
 } from './inspection-cache.js';
 
-const DEFAULT_CACHE_MODE: InspectionCacheMode = 'read_write';
+type EffectiveCacheMode = 'read_write' | 'read_only' | 'bypass' | 'write';
+const DEFAULT_CACHE_MODE: EffectiveCacheMode = 'read_write';
 const DEFAULT_MAX_AGE_HOURS = 24;
 
 /**
@@ -53,20 +57,25 @@ export async function inspectUrlNormalized(
   } = {}
 ): Promise<InspectionResultWithMetadata> {
   const tenantId = tenant?.tenantId || 'default';
-  const cacheMode = options.cacheMode || DEFAULT_CACHE_MODE;
+  const cacheMode = normalizeCacheMode(options.cacheMode);
   const maxAgeHours = options.maxAgeHours ?? DEFAULT_MAX_AGE_HOURS;
   const cacheKey = createInspectionCacheKey(tenantId, siteUrl, inspectionUrl);
+  const shouldReadCache = cacheMode === 'read_write' || cacheMode === 'read_only';
+  const shouldWriteCache = cacheMode === 'read_write' || cacheMode === 'write' || options.forceRefresh === true;
 
-  if (!options.forceRefresh && (cacheMode === 'read' || cacheMode === 'read_write')) {
+  if (!options.forceRefresh && shouldReadCache) {
     const cached = readFreshInspectionCache(tenantId, siteUrl, inspectionUrl, maxAgeHours);
     if (cached?.entry.normalized) {
+      const cachedAt = cached.entry.fetched_at;
       const metadata: InspectionCacheMetadata = {
         cacheHit: true,
         apiCallMade: false,
         quotaUnitEstimate: 0,
         cacheKey,
+        cachedAt,
         fetchedAt: cached.entry.fetched_at,
-        expiresAt: cached.entry.expires_at
+        expiresAt: cached.entry.expires_at,
+        cacheAgeHours: calculateCacheAgeHours(cachedAt)
       };
       appendInspectionCacheEvent({
         timestamp: new Date().toISOString(),
@@ -83,25 +92,25 @@ export async function inspectUrlNormalized(
     }
   }
 
-  if (cacheMode === 'read') {
+  if (cacheMode === 'read_only') {
     appendInspectionCacheEvent({
       timestamp: new Date().toISOString(),
       tenant_id: tenantId,
       siteUrl,
       inspectionUrl,
       tool_version: 'gsc-url-inspection-v1',
-      status: 'cache_miss',
+      status: 'provider_error',
       cacheHit: false,
       apiCallMade: false,
       quotaUnitEstimate: 0
     });
-    throw cacheMissError('Cache miss for URL Inspection result');
+    throw cacheMissError('No fresh cache entry and cacheMode is read_only');
   }
 
   try {
     const raw = await inspectUrl(siteUrl, inspectionUrl, languageCode);
     const normalized = normalizeInspectionResponse(siteUrl, inspectionUrl, raw);
-    const entry = cacheMode === 'write' || cacheMode === 'read_write'
+    const entry = shouldWriteCache
       ? writeInspectionCacheEntry(tenantId, siteUrl, inspectionUrl, raw, normalized, {
         ttlHours: maxAgeHours,
         apiStatus: 'ok'
@@ -113,8 +122,10 @@ export async function inspectUrlNormalized(
       apiCallMade: true,
       quotaUnitEstimate: 1,
       cacheKey,
+      cachedAt: entry?.fetched_at,
       fetchedAt: entry?.fetched_at || new Date().toISOString(),
-      expiresAt: entry?.expires_at
+      expiresAt: entry?.expires_at,
+      cacheAgeHours: entry ? 0 : undefined
     };
     appendInspectionCacheEvent({
       timestamp: new Date().toISOString(),
@@ -133,7 +144,7 @@ export async function inspectUrlNormalized(
     const err = error as any;
     const errorCode = String(err.code || err.status || err.reason || 'UNKNOWN');
     const errorMessage = sanitizeForLog(err.message || 'URL Inspection API call failed');
-    if (cacheMode === 'write' || cacheMode === 'read_write') {
+    if (shouldWriteCache) {
       writeInspectionCacheEntry(tenantId, siteUrl, inspectionUrl, undefined, undefined, {
         ttlHours: maxAgeHours,
         apiStatus: 'error',
@@ -193,24 +204,82 @@ export async function inspectBatchWithCache(
   } = {}
 ) {
   const tenantId = tenant?.tenantId || 'default';
-  const cacheMode = options.cacheMode || DEFAULT_CACHE_MODE;
+  const cacheMode = normalizeCacheMode(options.cacheMode);
   const maxAgeHours = options.maxAgeHours ?? DEFAULT_MAX_AGE_HOURS;
   const maxApiCallsPerRun = options.maxApiCallsPerRun ?? tenant?.limits.maxBatchUrls ?? 10;
+  const shouldReadCache = cacheMode === 'read_write' || cacheMode === 'read_only';
   let apiCallsMade = 0;
   let cacheHits = 0;
   let errors = 0;
   let quotaLimited = 0;
+  let invalidUrls = 0;
+  let forbiddenUrls = 0;
 
   const results = [];
 
-  for (const url of urls) {
+  for (const batch of chunkArray(urls, Number(process.env.MCP_INSPECTION_CHUNK_SIZE || 25))) {
+    for (const url of batch) {
     try {
-      const cached = !options.forceRefresh && (cacheMode === 'read' || cacheMode === 'read_write')
+      const normalizedUrl = normalizeInspectionUrlForCache(url);
+      if (!isInspectableUrl(url)) {
+        invalidUrls++;
+        results.push({
+          url,
+          inspectionUrl: url,
+          siteUrl,
+          status: 'invalid_url',
+          errorCode: 'INVALID_URL',
+          errorMessage: 'URL must be a valid http or https URL',
+          metadata: emptyMetadata(tenantId, siteUrl, url)
+        });
+        appendInspectionCacheEvent({
+          timestamp: new Date().toISOString(),
+          tenant_id: tenantId,
+          siteUrl,
+          inspectionUrl: url,
+          tool_version: 'gsc-url-inspection-v1',
+          status: 'invalid_url',
+          cacheHit: false,
+          apiCallMade: false,
+          quotaUnitEstimate: 0,
+          error_code: 'INVALID_URL'
+        });
+        continue;
+      }
+
+      if (tenant && !isUrlAllowedForTenant(tenant, url)) {
+        forbiddenUrls++;
+        results.push({
+          url: normalizedUrl,
+          inspectionUrl: url,
+          siteUrl,
+          status: 'forbidden_url',
+          errorCode: 'FORBIDDEN_URL',
+          errorMessage: 'URL is not allowed for this tenant',
+          metadata: emptyMetadata(tenantId, siteUrl, url)
+        });
+        appendInspectionCacheEvent({
+          timestamp: new Date().toISOString(),
+          tenant_id: tenantId,
+          siteUrl,
+          inspectionUrl: url,
+          tool_version: 'gsc-url-inspection-v1',
+          status: 'forbidden_url',
+          cacheHit: false,
+          apiCallMade: false,
+          quotaUnitEstimate: 0,
+          error_code: 'FORBIDDEN_URL'
+        });
+        continue;
+      }
+
+      const cached = !options.forceRefresh && shouldReadCache
         ? readFreshInspectionCache(tenantId, siteUrl, url, maxAgeHours)
         : undefined;
 
       if (cached?.entry.normalized) {
         cacheHits++;
+        const cachedAt = cached.entry.fetched_at;
         appendInspectionCacheEvent({
           timestamp: new Date().toISOString(),
           tenant_id: tenantId,
@@ -223,25 +292,30 @@ export async function inspectBatchWithCache(
           quotaUnitEstimate: 0
         });
         results.push({
-          status: 'ok',
+          status: 'cache_hit',
           ...cached.entry.normalized,
           metadata: {
             cacheHit: true,
             apiCallMade: false,
             quotaUnitEstimate: 0,
             cacheKey: createInspectionCacheKey(tenantId, siteUrl, url),
+            cachedAt,
             fetchedAt: cached.entry.fetched_at,
-            expiresAt: cached.entry.expires_at
+            expiresAt: cached.entry.expires_at,
+            cacheAgeHours: calculateCacheAgeHours(cachedAt)
           }
         });
         continue;
       }
 
-      if (cacheMode === 'read') {
+      if (cacheMode === 'read_only') {
         results.push({
+          url: normalizedUrl,
           inspectionUrl: url,
           siteUrl,
-          status: 'cache_miss',
+          status: 'provider_error',
+          errorCode: 'CACHE_MISS_READ_ONLY',
+          errorMessage: 'No fresh cache entry and cacheMode is read_only',
           metadata: {
             cacheHit: false,
             apiCallMade: false,
@@ -255,7 +329,7 @@ export async function inspectBatchWithCache(
           siteUrl,
           inspectionUrl: url,
           tool_version: 'gsc-url-inspection-v1',
-          status: 'cache_miss',
+          status: 'provider_error',
           cacheHit: false,
           apiCallMade: false,
           quotaUnitEstimate: 0
@@ -266,6 +340,7 @@ export async function inspectBatchWithCache(
       if (apiCallsMade >= maxApiCallsPerRun) {
         quotaLimited++;
         results.push({
+          url: normalizedUrl,
           inspectionUrl: url,
           siteUrl,
           status: 'quota_limited',
@@ -292,17 +367,18 @@ export async function inspectBatchWithCache(
 
       apiCallsMade++;
       const result = await inspectUrlNormalized(siteUrl, url, options.languageCode, tenant, {
-        cacheMode: cacheMode === 'write' ? 'write' : 'read_write',
+        cacheMode: cacheMode === 'bypass' ? 'bypass' : cacheMode === 'write' ? 'write' : 'read_write',
         maxAgeHours,
-        forceRefresh: true
+        forceRefresh: cacheMode === 'bypass' ? options.forceRefresh === true : true
       });
       results.push({ status: 'ok', ...result });
     } catch (error) {
       errors++;
       results.push({
+        url,
         inspectionUrl: url,
         siteUrl,
-        status: 'error',
+        status: 'provider_error',
         errorCode: String((error as any).code || (error as any).status || 'ERROR'),
         errorMessage: sanitizeForLog((error as Error).message || 'URL Inspection failed'),
         metadata: {
@@ -313,6 +389,7 @@ export async function inspectBatchWithCache(
         }
       });
     }
+  }
   }
 
   return {
@@ -326,11 +403,54 @@ export async function inspectBatchWithCache(
       cacheHits,
       apiCallsMade,
       errors,
+      invalidUrls,
+      forbiddenUrls,
       quotaLimited,
       quotaUnitEstimate: apiCallsMade
     },
     results
   };
+}
+
+function normalizeCacheMode(cacheMode?: InspectionCacheMode): EffectiveCacheMode {
+  if (cacheMode === 'read') return 'read_only';
+  if (cacheMode === 'write') return 'write';
+  if (cacheMode === 'read_only' || cacheMode === 'bypass' || cacheMode === 'read_write') return cacheMode;
+  return DEFAULT_CACHE_MODE;
+}
+
+function isInspectableUrl(url: string) {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isUrlAllowedForTenant(tenant: TenantContext, url: string) {
+  return isUrlAllowedBySites(url, [
+    ...(tenant.engines.google?.allowedSites || []),
+    ...(tenant.engines.bing?.allowedSites || [])
+  ]);
+}
+
+function emptyMetadata(tenantId: string, siteUrl: string, url: string): InspectionCacheMetadata {
+  return {
+    cacheHit: false,
+    apiCallMade: false,
+    quotaUnitEstimate: 0,
+    cacheKey: createInspectionCacheKey(tenantId, siteUrl, url)
+  };
+}
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunkSize = Math.max(1, Math.floor(size));
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize));
+  }
+  return chunks;
 }
 
 function cacheMissError(message: string) {

--- a/src/google/tools/inspection.ts
+++ b/src/google/tools/inspection.ts
@@ -1,6 +1,21 @@
 import { getSearchConsoleClient } from '../client.js';
 import { searchconsole_v1 } from 'googleapis';
 import { limitConcurrency } from '../../common/concurrency.js';
+import { TenantContext } from '../../tenant/types.js';
+import { sanitizeForLog } from '../../utils/redaction.js';
+import {
+  appendInspectionCacheEvent,
+  InspectionCacheMetadata,
+  InspectionCacheMode,
+  InspectionResultWithMetadata,
+  normalizeInspectionResponse,
+  readFreshInspectionCache,
+  writeInspectionCacheEntry,
+  createInspectionCacheKey
+} from './inspection-cache.js';
+
+const DEFAULT_CACHE_MODE: InspectionCacheMode = 'read_write';
+const DEFAULT_MAX_AGE_HOURS = 24;
 
 /**
  * Inspects a URL for a site to see its current indexing status in Google Search.
@@ -26,6 +41,122 @@ export async function inspectUrl(
   return res.data;
 }
 
+export async function inspectUrlNormalized(
+  siteUrl: string,
+  inspectionUrl: string,
+  languageCode: string = 'en-US',
+  tenant?: TenantContext,
+  options: {
+    cacheMode?: InspectionCacheMode;
+    maxAgeHours?: number;
+    forceRefresh?: boolean;
+  } = {}
+): Promise<InspectionResultWithMetadata> {
+  const tenantId = tenant?.tenantId || 'default';
+  const cacheMode = options.cacheMode || DEFAULT_CACHE_MODE;
+  const maxAgeHours = options.maxAgeHours ?? DEFAULT_MAX_AGE_HOURS;
+  const cacheKey = createInspectionCacheKey(tenantId, siteUrl, inspectionUrl);
+
+  if (!options.forceRefresh && (cacheMode === 'read' || cacheMode === 'read_write')) {
+    const cached = readFreshInspectionCache(tenantId, siteUrl, inspectionUrl, maxAgeHours);
+    if (cached?.entry.normalized) {
+      const metadata: InspectionCacheMetadata = {
+        cacheHit: true,
+        apiCallMade: false,
+        quotaUnitEstimate: 0,
+        cacheKey,
+        fetchedAt: cached.entry.fetched_at,
+        expiresAt: cached.entry.expires_at
+      };
+      appendInspectionCacheEvent({
+        timestamp: new Date().toISOString(),
+        tenant_id: tenantId,
+        siteUrl,
+        inspectionUrl,
+        tool_version: cached.entry.tool_version,
+        status: 'ok',
+        cacheHit: true,
+        apiCallMade: false,
+        quotaUnitEstimate: 0
+      });
+      return { ...cached.entry.normalized, metadata };
+    }
+  }
+
+  if (cacheMode === 'read') {
+    appendInspectionCacheEvent({
+      timestamp: new Date().toISOString(),
+      tenant_id: tenantId,
+      siteUrl,
+      inspectionUrl,
+      tool_version: 'gsc-url-inspection-v1',
+      status: 'cache_miss',
+      cacheHit: false,
+      apiCallMade: false,
+      quotaUnitEstimate: 0
+    });
+    throw cacheMissError('Cache miss for URL Inspection result');
+  }
+
+  try {
+    const raw = await inspectUrl(siteUrl, inspectionUrl, languageCode);
+    const normalized = normalizeInspectionResponse(siteUrl, inspectionUrl, raw);
+    const entry = cacheMode === 'write' || cacheMode === 'read_write'
+      ? writeInspectionCacheEntry(tenantId, siteUrl, inspectionUrl, raw, normalized, {
+        ttlHours: maxAgeHours,
+        apiStatus: 'ok'
+      })
+      : undefined;
+
+    const metadata: InspectionCacheMetadata = {
+      cacheHit: false,
+      apiCallMade: true,
+      quotaUnitEstimate: 1,
+      cacheKey,
+      fetchedAt: entry?.fetched_at || new Date().toISOString(),
+      expiresAt: entry?.expires_at
+    };
+    appendInspectionCacheEvent({
+      timestamp: new Date().toISOString(),
+      tenant_id: tenantId,
+      siteUrl,
+      inspectionUrl,
+      tool_version: 'gsc-url-inspection-v1',
+      status: 'ok',
+      cacheHit: false,
+      apiCallMade: true,
+      quotaUnitEstimate: 1
+    });
+
+    return { ...normalized, metadata };
+  } catch (error) {
+    const err = error as any;
+    const errorCode = String(err.code || err.status || err.reason || 'UNKNOWN');
+    const errorMessage = sanitizeForLog(err.message || 'URL Inspection API call failed');
+    if (cacheMode === 'write' || cacheMode === 'read_write') {
+      writeInspectionCacheEntry(tenantId, siteUrl, inspectionUrl, undefined, undefined, {
+        ttlHours: maxAgeHours,
+        apiStatus: 'error',
+        errorCode,
+        errorMessage
+      });
+    }
+    appendInspectionCacheEvent({
+      timestamp: new Date().toISOString(),
+      tenant_id: tenantId,
+      siteUrl,
+      inspectionUrl,
+      tool_version: 'gsc-url-inspection-v1',
+      status: 'error',
+      cacheHit: false,
+      apiCallMade: true,
+      quotaUnitEstimate: 1,
+      error_code: errorCode
+    });
+    throw new Error(errorMessage);
+  }
+}
+
 /**
  * Inspects multiple URLs for a site in batch.
  *
@@ -47,4 +178,163 @@ export async function inspectBatch(
       return { url, error: (error as Error).message };
     }
   });
+}
+
+export async function inspectBatchWithCache(
+  siteUrl: string,
+  urls: string[],
+  tenant: TenantContext | undefined,
+  options: {
+    cacheMode?: InspectionCacheMode;
+    maxAgeHours?: number;
+    forceRefresh?: boolean;
+    languageCode?: string;
+    maxApiCallsPerRun?: number;
+  } = {}
+) {
+  const tenantId = tenant?.tenantId || 'default';
+  const cacheMode = options.cacheMode || DEFAULT_CACHE_MODE;
+  const maxAgeHours = options.maxAgeHours ?? DEFAULT_MAX_AGE_HOURS;
+  const maxApiCallsPerRun = options.maxApiCallsPerRun ?? tenant?.limits.maxBatchUrls ?? 10;
+  let apiCallsMade = 0;
+  let cacheHits = 0;
+  let errors = 0;
+  let quotaLimited = 0;
+
+  const results = [];
+
+  for (const url of urls) {
+    try {
+      const cached = !options.forceRefresh && (cacheMode === 'read' || cacheMode === 'read_write')
+        ? readFreshInspectionCache(tenantId, siteUrl, url, maxAgeHours)
+        : undefined;
+
+      if (cached?.entry.normalized) {
+        cacheHits++;
+        appendInspectionCacheEvent({
+          timestamp: new Date().toISOString(),
+          tenant_id: tenantId,
+          siteUrl,
+          inspectionUrl: url,
+          tool_version: cached.entry.tool_version,
+          status: 'ok',
+          cacheHit: true,
+          apiCallMade: false,
+          quotaUnitEstimate: 0
+        });
+        results.push({
+          status: 'ok',
+          ...cached.entry.normalized,
+          metadata: {
+            cacheHit: true,
+            apiCallMade: false,
+            quotaUnitEstimate: 0,
+            cacheKey: createInspectionCacheKey(tenantId, siteUrl, url),
+            fetchedAt: cached.entry.fetched_at,
+            expiresAt: cached.entry.expires_at
+          }
+        });
+        continue;
+      }
+
+      if (cacheMode === 'read') {
+        results.push({
+          inspectionUrl: url,
+          siteUrl,
+          status: 'cache_miss',
+          metadata: {
+            cacheHit: false,
+            apiCallMade: false,
+            quotaUnitEstimate: 0,
+            cacheKey: createInspectionCacheKey(tenantId, siteUrl, url)
+          }
+        });
+        appendInspectionCacheEvent({
+          timestamp: new Date().toISOString(),
+          tenant_id: tenantId,
+          siteUrl,
+          inspectionUrl: url,
+          tool_version: 'gsc-url-inspection-v1',
+          status: 'cache_miss',
+          cacheHit: false,
+          apiCallMade: false,
+          quotaUnitEstimate: 0
+        });
+        continue;
+      }
+
+      if (apiCallsMade >= maxApiCallsPerRun) {
+        quotaLimited++;
+        results.push({
+          inspectionUrl: url,
+          siteUrl,
+          status: 'quota_limited',
+          metadata: {
+            cacheHit: false,
+            apiCallMade: false,
+            quotaUnitEstimate: 0,
+            cacheKey: createInspectionCacheKey(tenantId, siteUrl, url)
+          }
+        });
+        appendInspectionCacheEvent({
+          timestamp: new Date().toISOString(),
+          tenant_id: tenantId,
+          siteUrl,
+          inspectionUrl: url,
+          tool_version: 'gsc-url-inspection-v1',
+          status: 'quota_limited',
+          cacheHit: false,
+          apiCallMade: false,
+          quotaUnitEstimate: 0
+        });
+        continue;
+      }
+
+      apiCallsMade++;
+      const result = await inspectUrlNormalized(siteUrl, url, options.languageCode, tenant, {
+        cacheMode: cacheMode === 'write' ? 'write' : 'read_write',
+        maxAgeHours,
+        forceRefresh: true
+      });
+      results.push({ status: 'ok', ...result });
+    } catch (error) {
+      errors++;
+      results.push({
+        inspectionUrl: url,
+        siteUrl,
+        status: 'error',
+        errorCode: String((error as any).code || (error as any).status || 'ERROR'),
+        errorMessage: sanitizeForLog((error as Error).message || 'URL Inspection failed'),
+        metadata: {
+          cacheHit: false,
+          apiCallMade: true,
+          quotaUnitEstimate: 1,
+          cacheKey: createInspectionCacheKey(tenantId, siteUrl, url)
+        }
+      });
+    }
+  }
+
+  return {
+    siteUrl,
+    cacheMode,
+    maxAgeHours,
+    maxApiCallsPerRun,
+    summary: {
+      requested: urls.length,
+      returned: results.length,
+      cacheHits,
+      apiCallsMade,
+      errors,
+      quotaLimited,
+      quotaUnitEstimate: apiCallsMade
+    },
+    results
+  };
+}
+
+function cacheMissError(message: string) {
+  const error = new Error(message) as Error & { code: string };
+  error.code = 'CACHE_MISS';
+  return error;
 }

--- a/src/google/tools/inspection.ts
+++ b/src/google/tools/inspection.ts
@@ -4,6 +4,7 @@ import { limitConcurrency } from '../../common/concurrency.js';
 import { TenantContext } from '../../tenant/types.js';
 import { isUrlAllowedBySites } from '../../tenant/guard.js';
 import { sanitizeForLog } from '../../utils/redaction.js';
+import { runGoogleApiCall } from '../upstream.js';
 import {
   appendInspectionCacheEvent,
   calculateCacheAgeHours,
@@ -35,13 +36,15 @@ export async function inspectUrl(
   languageCode: string = 'en-US'
 ): Promise<searchconsole_v1.Schema$InspectUrlIndexResponse> {
   const client = await getSearchConsoleClient(siteUrl);
-  const res = await client.urlInspection.index.inspect({
-    requestBody: {
-      inspectionUrl,
-      siteUrl,
-      languageCode
-    }
-  });
+  const res = await runGoogleApiCall('urlInspection.index.inspect', (requestOptions) =>
+    client.urlInspection.index.inspect({
+      requestBody: {
+        inspectionUrl,
+        siteUrl,
+        languageCode
+      }
+    }, requestOptions)
+  );
   return res.data;
 }
 

--- a/src/google/tools/pagespeed.ts
+++ b/src/google/tools/pagespeed.ts
@@ -1,6 +1,8 @@
 import { google, pagespeedonline_v5 } from 'googleapis';
+import { existsSync, readFileSync } from 'node:fs';
 
 const pagespeed = google.pagespeedonline('v5');
+let cachedApiKey: string | undefined;
 
 /**
  * Summary of PageSpeed Insights analysis results, including scores and CWV.
@@ -51,7 +53,8 @@ export async function analyzePageSpeed(
     const res = await pagespeed.pagespeedapi.runpagespeed({
         url,
         strategy,
-        category: ['performance', 'accessibility', 'best-practices', 'seo']
+        category: ['performance', 'accessibility', 'best-practices', 'seo'],
+        key: getPageSpeedApiKey()
     });
 
     const data = res.data;
@@ -94,6 +97,28 @@ export async function analyzePageSpeed(
         coreWebVitals,
         loadingExperience
     };
+}
+
+function getPageSpeedApiKey(): string | undefined {
+    if (cachedApiKey !== undefined) return cachedApiKey || undefined;
+
+    const direct = process.env.PAGESPEED_API_KEY || process.env.GOOGLE_WEB_VITALS_API_KEY;
+    if (direct?.trim()) {
+        cachedApiKey = direct.trim();
+        return cachedApiKey;
+    }
+
+    const filePath = process.env.PAGESPEED_API_KEY_FILE
+        || process.env.CRUX_API_KEY_FILE
+        || process.env.GOOGLE_WEB_VITALS_API_KEY_FILE;
+
+    if (filePath && existsSync(filePath)) {
+        cachedApiKey = readFileSync(filePath, 'utf8').trim();
+        return cachedApiKey || undefined;
+    }
+
+    cachedApiKey = '';
+    return undefined;
 }
 
 /**

--- a/src/google/tools/sitemaps.ts
+++ b/src/google/tools/sitemaps.ts
@@ -1,5 +1,6 @@
 import { getSearchConsoleClient } from '../client.js';
 import { searchconsole_v1 } from 'googleapis';
+import { runGoogleApiCall } from '../upstream.js';
 
 /**
  * List all sitemaps submitted for a specific site.
@@ -9,7 +10,9 @@ import { searchconsole_v1 } from 'googleapis';
  */
 export async function listSitemaps(siteUrl: string): Promise<searchconsole_v1.Schema$WmxSitemap[]> {
   const client = await getSearchConsoleClient(siteUrl);
-  const res = await client.sitemaps.list({ siteUrl });
+  const res = await runGoogleApiCall('sitemaps.list', (requestOptions) =>
+    client.sitemaps.list({ siteUrl }, requestOptions)
+  );
   return res.data.sitemap || [];
 }
 
@@ -22,7 +25,9 @@ export async function listSitemaps(siteUrl: string): Promise<searchconsole_v1.Sc
  */
 export async function submitSitemap(siteUrl: string, feedpath: string): Promise<string> {
   const client = await getSearchConsoleClient(siteUrl);
-  await client.sitemaps.submit({ siteUrl, feedpath });
+  await runGoogleApiCall('sitemaps.submit', (requestOptions) =>
+    client.sitemaps.submit({ siteUrl, feedpath }, requestOptions)
+  );
   return `Successfully submitted sitemap: ${feedpath} for ${siteUrl}`;
 }
 
@@ -35,7 +40,9 @@ export async function submitSitemap(siteUrl: string, feedpath: string): Promise<
  */
 export async function deleteSitemap(siteUrl: string, feedpath: string): Promise<string> {
   const client = await getSearchConsoleClient(siteUrl);
-  await client.sitemaps.delete({ siteUrl, feedpath });
+  await runGoogleApiCall('sitemaps.delete', (requestOptions) =>
+    client.sitemaps.delete({ siteUrl, feedpath }, requestOptions)
+  );
   return `Successfully deleted sitemap: ${feedpath} from ${siteUrl}`;
 }
 
@@ -48,6 +55,8 @@ export async function deleteSitemap(siteUrl: string, feedpath: string): Promise<
  */
 export async function getSitemap(siteUrl: string, feedpath: string): Promise<searchconsole_v1.Schema$WmxSitemap> {
   const client = await getSearchConsoleClient(siteUrl);
-  const res = await client.sitemaps.get({ siteUrl, feedpath });
+  const res = await runGoogleApiCall('sitemaps.get', (requestOptions) =>
+    client.sitemaps.get({ siteUrl, feedpath }, requestOptions)
+  );
   return res.data;
 }

--- a/src/google/tools/sites.ts
+++ b/src/google/tools/sites.ts
@@ -1,5 +1,6 @@
 import { getSearchConsoleClient } from '../client.js';
 import { searchconsole_v1 } from 'googleapis';
+import { runGoogleApiCall } from '../upstream.js';
 
 /**
  * List all sites verified in the specified Google account.
@@ -9,7 +10,9 @@ import { searchconsole_v1 } from 'googleapis';
  */
 export async function listSites(accountId?: string): Promise<searchconsole_v1.Schema$WmxSite[]> {
   const client = await getSearchConsoleClient(undefined, accountId);
-  const res = await client.sites.list();
+  const res = await runGoogleApiCall('sites.list', (requestOptions) =>
+    client.sites.list({}, requestOptions)
+  );
   return res.data.siteEntry || [];
 }
 
@@ -21,7 +24,9 @@ export async function listSites(accountId?: string): Promise<searchconsole_v1.Sc
  */
 export async function addSite(siteUrl: string): Promise<string> {
   const client = await getSearchConsoleClient(siteUrl);
-  await client.sites.add({ siteUrl });
+  await runGoogleApiCall('sites.add', (requestOptions) =>
+    client.sites.add({ siteUrl }, requestOptions)
+  );
   return `Successfully added site: ${siteUrl}`;
 }
 
@@ -33,7 +38,9 @@ export async function addSite(siteUrl: string): Promise<string> {
  */
 export async function deleteSite(siteUrl: string): Promise<string> {
   const client = await getSearchConsoleClient(siteUrl);
-  await client.sites.delete({ siteUrl });
+  await runGoogleApiCall('sites.delete', (requestOptions) =>
+    client.sites.delete({ siteUrl }, requestOptions)
+  );
   return `Successfully deleted site: ${siteUrl}`;
 }
 
@@ -45,6 +52,8 @@ export async function deleteSite(siteUrl: string): Promise<string> {
  */
 export async function getSite(siteUrl: string): Promise<searchconsole_v1.Schema$WmxSite> {
   const client = await getSearchConsoleClient(siteUrl);
-  const res = await client.sites.get({ siteUrl });
+  const res = await runGoogleApiCall('sites.get', (requestOptions) =>
+    client.sites.get({ siteUrl }, requestOptions)
+  );
   return res.data;
 }

--- a/src/google/upstream.ts
+++ b/src/google/upstream.ts
@@ -1,0 +1,76 @@
+import { getCurrentTenant } from '../tenant/context.js';
+import { TenantContext } from '../tenant/types.js';
+import { logger } from '../utils/logger.js';
+
+const DEFAULT_GOOGLE_API_TIMEOUT_MS = 110_000;
+const MIN_GOOGLE_API_TIMEOUT_MS = 1_000;
+const MAX_GOOGLE_API_TIMEOUT_MS = 300_000;
+
+export interface GoogleApiCallOptions {
+  timeout: number;
+}
+
+export function getGoogleApiTimeoutMs(tenant: TenantContext | undefined = getCurrentTenant()): number {
+  const override = parsePositiveInteger(process.env.MCP_GOOGLE_API_TIMEOUT_MS);
+  if (override) {
+    return clampTimeoutMs(override);
+  }
+
+  const tenantTimeoutSeconds = tenant?.limits.requestTimeoutSeconds;
+  if (tenantTimeoutSeconds) {
+    return clampTimeoutMs(tenantTimeoutSeconds * 1000);
+  }
+
+  return DEFAULT_GOOGLE_API_TIMEOUT_MS;
+}
+
+export async function runGoogleApiCall<T>(
+  operation: string,
+  call: (options: GoogleApiCallOptions) => Promise<T>
+): Promise<T> {
+  const tenant = getCurrentTenant();
+  const timeoutMs = getGoogleApiTimeoutMs(tenant);
+  const startedAt = Date.now();
+
+  try {
+    const result = await call({ timeout: timeoutMs });
+    logger.info('Google API call completed', {
+      tenantId: tenant?.tenantId || 'none',
+      operation,
+      durationMs: Date.now() - startedAt,
+      timeoutMs,
+      status: 'ok'
+    });
+    return result;
+  } catch (error) {
+    logger.warn('Google API call failed', {
+      tenantId: tenant?.tenantId || 'none',
+      operation,
+      durationMs: Date.now() - startedAt,
+      timeoutMs,
+      status: 'error',
+      upstreamStatus: getUpstreamStatus(error)
+    });
+    throw error;
+  }
+}
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+}
+
+function clampTimeoutMs(value: number): number {
+  return Math.min(MAX_GOOGLE_API_TIMEOUT_MS, Math.max(MIN_GOOGLE_API_TIMEOUT_MS, value));
+}
+
+function getUpstreamStatus(error: unknown): string {
+  const err = error as {
+    code?: string | number;
+    status?: string | number;
+    response?: { status?: string | number };
+  };
+  return String(err?.response?.status || err?.status || err?.code || 'unknown');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -734,7 +734,7 @@ server.tool(
     siteUrl: z.string().describe("The URL of the property"),
     inspectionUrl: z.string().describe("The fully-qualified URL to inspect"),
     languageCode: z.string().optional().describe("Language code for localized results (Google only)"),
-    cacheMode: z.enum(["read", "write", "read_write"]).optional().describe("Cache behavior for Google inspection (default: read_write)"),
+    cacheMode: z.enum(["read_write", "read_only", "bypass", "read", "write"]).optional().describe("Cache behavior for Google inspection: read_write, read_only, or bypass (default: read_write; read/write are deprecated aliases)"),
     maxAgeHours: z.number().optional().describe("Maximum cache age in hours (default: 24)"),
     forceRefresh: z.boolean().optional().describe("Bypass fresh cache and call Google API (default: false)"),
     engine: z.enum(["google", "bing"]).optional().describe("The search engine (default: google)")
@@ -759,7 +759,7 @@ server.tool(
   {
     siteUrl: z.string().describe("The Search Console property URL"),
     urls: z.array(z.string()).describe("Fully-qualified URLs to inspect"),
-    cacheMode: z.enum(["read", "write", "read_write"]).optional().describe("Cache behavior (default: read_write)"),
+    cacheMode: z.enum(["read_write", "read_only", "bypass", "read", "write"]).optional().describe("Cache behavior: read_write, read_only, or bypass (default: read_write; read/write are deprecated aliases)"),
     maxAgeHours: z.number().optional().describe("Maximum cache age in hours (default: 24; use 12 for fresh_url flows)"),
     forceRefresh: z.boolean().optional().describe("Bypass fresh cache and call Google API until per-run quota limit is reached"),
     languageCode: z.string().optional().describe("Language code for localized Google results")

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,10 @@ import { registerPrompts } from "./prompts/index.js";
 import { jsonToCsv } from "./common/utils/csv.js";
 import { runDiagnostics } from "./common/diagnostics.js";
 import { logger } from "./utils/logger.js";
+import { installTenantGuard } from "./tenant/tool-guard.js";
+import { startHttpServer } from "./tenant/http.js";
+import { getCurrentTenant } from "./tenant/context.js";
+import { forbidden } from "./tenant/errors.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -78,6 +82,8 @@ const server = new McpServer({
   name: "search-console-mcp",
   version: version,
 });
+
+installTenantGuard(server);
 
 // Get Started Tool
 server.tool(
@@ -1556,13 +1562,38 @@ server.tool(
   "Submit URLs via IndexNow API (Bing, Yandex, etc.)",
   {
     host: z.string().describe("The host/domain where URLs are located (e.g., www.example.com)"),
-    key: z.string().describe("The IndexNow key generated for this host"),
+    key: z.string().optional().describe("The IndexNow key generated for this host. In tenant HTTP mode this is resolved server-side and must be omitted."),
     keyLocation: z.string().optional().describe("Optional URL of the key file (if not at host root)"),
     urlList: z.array(z.string()).describe("List of absolute URLs to notify IndexNow about")
   },
   async (options) => {
     try {
-      const result = await indexNow.submitIndexNow(options);
+      const tenant = getCurrentTenant();
+      let key = options.key;
+      let keyLocation = options.keyLocation;
+
+      if (tenant) {
+        if (options.key) {
+          throw forbidden("403 Forbidden: IndexNow key must be configured server-side for tenant calls");
+        }
+        const tenantKey = tenant.indexNowKeys[options.host.toLowerCase()];
+        if (!tenantKey) {
+          throw forbidden("403 Forbidden: IndexNow key is not configured for this tenant host");
+        }
+        key = tenantKey.key;
+        keyLocation = tenantKey.keyLocation;
+      }
+
+      if (!key) {
+        throw new Error("IndexNow key is required");
+      }
+
+      const result = await indexNow.submitIndexNow({
+        host: options.host,
+        key,
+        keyLocation,
+        urlList: options.urlList
+      });
       return {
         content: [{ type: "text", text: result }]
       };
@@ -2642,6 +2673,12 @@ async function main() {
     return;
   }
 
+  if (command === 'tenants' || command === 'tokens') {
+    const { main: tenantCliMain } = await import('./tenant/cli.js');
+    await tenantCliMain(process.argv.slice(2));
+    return;
+  }
+
   if (command === 'logout') {
     const { runLogout } = await import('./setup.js');
     await runLogout();
@@ -2657,6 +2694,11 @@ async function main() {
   if (command === 'diagnostics') {
     const results = await runDiagnostics();
     console.log(JSON.stringify(results, null, 2));
+    return;
+  }
+
+  if (command === 'serve-http' || process.env.MCP_TRANSPORT === 'http') {
+    await startHttpServer(server);
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,13 @@ import { getSearchConsoleClient } from './google/client.js';
 import { getBingClient } from './bing/client.js';
 import { limitConcurrency } from './common/concurrency.js';
 import {
+  dimensionsDocs,
+  filtersDocs,
+  searchTypesDocs,
+  patternsDocs,
+  algorithmUpdatesDocs
+} from "./google/docs/index.js";
+import {
   bingApiDocs,
   indexNowDocs,
   dimensionsDocs as bingDimensionsDocs,
@@ -78,6 +85,7 @@ try {
   // Fallback for cases where package.json might not be accessible
 }
 
+export function createMcpServer() {
 const server = new McpServer({
   name: "search-console-mcp",
   version: version,
@@ -2195,8 +2203,6 @@ server.resource(
 );
 
 // Documentation Resources
-import { dimensionsDocs, filtersDocs, searchTypesDocs, patternsDocs, algorithmUpdatesDocs } from "./google/docs/index.js";
-
 server.resource(
   "docs-dimensions",
   "docs://dimensions",
@@ -2657,6 +2663,9 @@ server.tool(
   }
 );
 
+return server;
+}
+
 async function main() {
   const command = process.argv[2];
 
@@ -2698,7 +2707,7 @@ async function main() {
   }
 
   if (command === 'serve-http' || process.env.MCP_TRANSPORT === 'http') {
-    await startHttpServer(server);
+    await startHttpServer(createMcpServer);
     return;
   }
 
@@ -2748,6 +2757,7 @@ async function main() {
   }
 
   const transport = new StdioServerTransport();
+  const server = createMcpServer();
   await server.connect(transport);
 
   const googleStatus = hasGoogle ? `${colors.green}✔ Google${colors.reset}` : `${colors.red}✘ Google${colors.reset}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import * as sites from "./google/tools/sites.js";
 import * as sitemaps from "./google/tools/sitemaps.js";
 import * as analytics from "./google/tools/analytics.js";
 import * as inspection from "./google/tools/inspection.js";
+import * as inspectionJobs from "./google/tools/inspection-jobs.js";
 import * as pagespeed from "./google/tools/pagespeed.js";
 import * as seoInsights from "./google/tools/seo-insights.js";
 import * as seoPrimitives from "./common/tools/seo-primitives.js";
@@ -797,6 +798,103 @@ server.tool(
       const tenant = getCurrentTenant();
       if (!tenant) throw forbidden('403 Forbidden: tenant context is required for inspection cache stats');
       const result = getInspectionCacheStats(tenant, { siteUrl, startDate, endDate });
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      return formatError(error);
+    }
+  }
+);
+
+server.tool(
+  "inspection_batch_job_start",
+  "Start an asynchronous tenant-scoped Google URL Inspection batch job",
+  {
+    siteUrl: z.string().describe("The Search Console property URL"),
+    urls: z.array(z.string()).describe("Fully-qualified URLs to inspect"),
+    cacheMode: z.enum(["read_write", "read_only", "bypass", "read", "write"]).optional().describe("Cache behavior: read_write, read_only, or bypass (default: read_write; read/write are deprecated aliases)"),
+    maxAgeHours: z.number().optional().describe("Maximum cache age in hours (default: 24; use 12 for fresh_url flows)"),
+    forceRefresh: z.boolean().optional().describe("Bypass fresh cache and call Google API until per-run quota limit is reached"),
+    languageCode: z.string().optional().describe("Language code for localized Google results")
+  },
+  async ({ siteUrl, urls, cacheMode, maxAgeHours, forceRefresh, languageCode }) => {
+    try {
+      const tenant = getCurrentTenant();
+      if (!tenant) throw forbidden('403 Forbidden: tenant context is required for inspection batch jobs');
+      const maxApiCallsPerRun = Number(process.env.MCP_INSPECTION_MAX_API_CALLS_PER_RUN || tenant.limits.maxBatchUrls || 10);
+      const result = inspectionJobs.startInspectionBatchJob({
+        siteUrl,
+        urls,
+        tenant,
+        cacheMode,
+        maxAgeHours,
+        forceRefresh,
+        languageCode,
+        maxApiCallsPerRun
+      });
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      return formatError(error);
+    }
+  }
+);
+
+server.tool(
+  "inspection_batch_job_status",
+  "Return status for an asynchronous URL Inspection batch job",
+  {
+    jobId: z.string().describe("The job ID returned by inspection_batch_job_start")
+  },
+  async ({ jobId }) => {
+    try {
+      const tenant = getCurrentTenant();
+      if (!tenant) throw forbidden('403 Forbidden: tenant context is required for inspection batch jobs');
+      const result = inspectionJobs.getInspectionBatchJobStatus(tenant, jobId);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      return formatError(error);
+    }
+  }
+);
+
+server.tool(
+  "inspection_batch_job_results",
+  "Return partial or completed results for an asynchronous URL Inspection batch job",
+  {
+    jobId: z.string().describe("The job ID returned by inspection_batch_job_start"),
+    offset: z.number().optional().describe("Optional zero-based result offset for pagination"),
+    limit: z.number().optional().describe("Optional maximum number of results to return")
+  },
+  async ({ jobId, offset, limit }) => {
+    try {
+      const tenant = getCurrentTenant();
+      if (!tenant) throw forbidden('403 Forbidden: tenant context is required for inspection batch jobs');
+      const result = inspectionJobs.getInspectionBatchJobResults(tenant, jobId, { offset, limit });
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      return formatError(error);
+    }
+  }
+);
+
+server.tool(
+  "inspection_batch_job_cancel",
+  "Cancel a queued or running asynchronous URL Inspection batch job",
+  {
+    jobId: z.string().describe("The job ID returned by inspection_batch_job_start")
+  },
+  async ({ jobId }) => {
+    try {
+      const tenant = getCurrentTenant();
+      if (!tenant) throw forbidden('403 Forbidden: tenant context is required for inspection batch jobs');
+      const result = inspectionJobs.cancelInspectionBatchJob(tenant, jobId);
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ import { installTenantGuard } from "./tenant/tool-guard.js";
 import { startHttpServer } from "./tenant/http.js";
 import { getCurrentTenant } from "./tenant/context.js";
 import { forbidden } from "./tenant/errors.js";
+import { getInspectionCacheStats } from "./google/tools/inspection-cache.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -733,13 +734,69 @@ server.tool(
     siteUrl: z.string().describe("The URL of the property"),
     inspectionUrl: z.string().describe("The fully-qualified URL to inspect"),
     languageCode: z.string().optional().describe("Language code for localized results (Google only)"),
+    cacheMode: z.enum(["read", "write", "read_write"]).optional().describe("Cache behavior for Google inspection (default: read_write)"),
+    maxAgeHours: z.number().optional().describe("Maximum cache age in hours (default: 24)"),
+    forceRefresh: z.boolean().optional().describe("Bypass fresh cache and call Google API (default: false)"),
     engine: z.enum(["google", "bing"]).optional().describe("The search engine (default: google)")
   },
-  async ({ siteUrl, inspectionUrl, languageCode, engine = "google" }) => {
+  async ({ siteUrl, inspectionUrl, languageCode, cacheMode, maxAgeHours, forceRefresh, engine = "google" }) => {
     try {
       const result = engine === "google"
-        ? await inspection.inspectUrl(siteUrl, inspectionUrl, languageCode)
+        ? await inspection.inspectUrlNormalized(siteUrl, inspectionUrl, languageCode, getCurrentTenant(), { cacheMode, maxAgeHours, forceRefresh })
         : await bingInspection.getUrlInfo(siteUrl, inspectionUrl);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      return formatError(error);
+    }
+  }
+);
+
+server.tool(
+  "inspection_batch_inspect",
+  "Inspect multiple Google Search Console URLs with tenant-scoped cache and per-URL partial results",
+  {
+    siteUrl: z.string().describe("The Search Console property URL"),
+    urls: z.array(z.string()).describe("Fully-qualified URLs to inspect"),
+    cacheMode: z.enum(["read", "write", "read_write"]).optional().describe("Cache behavior (default: read_write)"),
+    maxAgeHours: z.number().optional().describe("Maximum cache age in hours (default: 24; use 12 for fresh_url flows)"),
+    forceRefresh: z.boolean().optional().describe("Bypass fresh cache and call Google API until per-run quota limit is reached"),
+    languageCode: z.string().optional().describe("Language code for localized Google results")
+  },
+  async ({ siteUrl, urls, cacheMode, maxAgeHours, forceRefresh, languageCode }) => {
+    try {
+      const tenant = getCurrentTenant();
+      const maxApiCallsPerRun = Number(process.env.MCP_INSPECTION_MAX_API_CALLS_PER_RUN || tenant?.limits.maxBatchUrls || 10);
+      const result = await inspection.inspectBatchWithCache(siteUrl, urls, tenant, {
+        cacheMode,
+        maxAgeHours,
+        forceRefresh,
+        languageCode,
+        maxApiCallsPerRun
+      });
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+      };
+    } catch (error) {
+      return formatError(error);
+    }
+  }
+);
+
+server.tool(
+  "inspection_cache_stats",
+  "Return tenant-scoped Google URL Inspection cache usage statistics",
+  {
+    siteUrl: z.string().optional().describe("Optional Search Console property URL to filter stats"),
+    startDate: z.string().optional().describe("Optional start date (YYYY-MM-DD)"),
+    endDate: z.string().optional().describe("Optional end date (YYYY-MM-DD)")
+  },
+  async ({ siteUrl, startDate, endDate }) => {
+    try {
+      const tenant = getCurrentTenant();
+      if (!tenant) throw forbidden('403 Forbidden: tenant context is required for inspection cache stats');
+      const result = getInspectionCacheStats(tenant, { siteUrl, startDate, endDate });
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };

--- a/src/tenant/cli.ts
+++ b/src/tenant/cli.ts
@@ -1,0 +1,193 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    appendTokenRecord,
+    createTokenRecord,
+    getTenantsDir,
+    getTokenRegistryPath,
+    loadTokenRegistry,
+    resetTenantRegistryCache
+} from './registry.js';
+import { TenantConfig, TenantConfigSchema, TokenRegistrySchema } from './types.js';
+
+export async function main(argv: string[]) {
+    const namespace = argv[0];
+    const command = argv[1];
+    const args = parseArgs(argv.slice(2));
+
+    if (namespace === 'tenants') {
+        if (command === 'list') return tenantsList();
+        if (command === 'validate') return tenantsValidate();
+        if (command === 'add') return tenantsAdd(args);
+    }
+
+    if (namespace === 'tokens') {
+        if (command === 'create') return tokensCreate(args);
+        if (command === 'revoke') return tokensRevoke(args);
+    }
+
+    printUsage();
+    process.exitCode = 1;
+}
+
+function tenantsList() {
+    const dir = getTenantsDir();
+    if (!existsSync(dir)) {
+        console.log(`No tenant directory found at ${dir}`);
+        return;
+    }
+
+    for (const file of readdirSync(dir).filter(file => file.endsWith('.json')).sort()) {
+        const parsed = TenantConfigSchema.parse(JSON.parse(readFileSync(join(dir, file), 'utf8')));
+        console.log(`${parsed.tenant_id}\t${parsed.enabled === false ? 'disabled' : 'enabled'}\t${parsed.display_name}`);
+    }
+}
+
+function tenantsValidate() {
+    const dir = getTenantsDir();
+    let count = 0;
+    if (!existsSync(dir)) {
+        throw new Error(`Tenant directory does not exist: ${dir}`);
+    }
+
+    for (const file of readdirSync(dir).filter(file => file.endsWith('.json')).sort()) {
+        TenantConfigSchema.parse(JSON.parse(readFileSync(join(dir, file), 'utf8')));
+        count++;
+    }
+
+    TokenRegistrySchema.parse(JSON.parse(readFileSync(getTokenRegistryPath(), 'utf8')));
+    console.log(`OK: validated ${count} tenant(s) and token registry`);
+}
+
+function tenantsAdd(args: Record<string, string | boolean>) {
+    const tenantId = requireStringArg(args, 'tenant');
+    const site = requireStringArg(args, 'site');
+    const dir = getTenantsDir();
+    mkdirSync(dir, { recursive: true });
+
+    const path = join(dir, `${safeFileName(tenantId)}.json`);
+    const existing: TenantConfig = existsSync(path)
+        ? TenantConfigSchema.parse(JSON.parse(readFileSync(path, 'utf8')))
+        : {
+            tenant_id: tenantId,
+            display_name: tenantId,
+            enabled: true,
+            admin: false,
+            engines: {
+                google: {
+                    account_ids: [],
+                    allowed_sites: [],
+                    default_site: site
+                }
+            },
+            allowed_tools: [
+                'get_started',
+                'sites_list',
+                'analytics_*',
+                'seo_*',
+                'inspection_*',
+                'pagespeed_*',
+                'schema_validate'
+            ],
+            denied_tools: [
+                'sites_add',
+                'sites_delete',
+                'sitemaps_submit',
+                'sitemaps_delete',
+                'bing_index_now'
+            ],
+            allow_mutations: false,
+            allowed_mutating_tools: [],
+            limits: {
+                max_rows: 25000,
+                max_batch_urls: 10,
+                request_timeout_seconds: 120
+            }
+        };
+
+    existing.engines.google ||= { account_ids: [], allowed_sites: [], default_site: site };
+    if (!existing.engines.google.allowed_sites.includes(site)) {
+        existing.engines.google.allowed_sites.push(site);
+    }
+    existing.engines.google.default_site ||= site;
+
+    const parsed = TenantConfigSchema.parse(existing);
+    writeFileSync(path, `${JSON.stringify(parsed, null, 2)}\n`, { mode: 0o600 });
+    resetTenantRegistryCache();
+    console.log(`Tenant ${tenantId} saved at ${path}`);
+}
+
+function tokensCreate(args: Record<string, string | boolean>) {
+    const tenantId = requireStringArg(args, 'tenant');
+    const description = typeof args.description === 'string' ? args.description : undefined;
+    const tokenId = typeof args['token-id'] === 'string' ? args['token-id'] : undefined;
+    const { plaintext, record } = createTokenRecord(tenantId, description, tokenId);
+
+    appendTokenRecord(record);
+
+    console.log(`token_id: ${record.token_id}`);
+    console.log(`tenant_id: ${record.tenant_id}`);
+    console.log(`bearer_token: ${plaintext}`);
+    console.log('Store this bearer token now. It will not be shown again.');
+}
+
+function tokensRevoke(args: Record<string, string | boolean>) {
+    const tokenId = requireStringArg(args, 'token-id');
+    const path = getTokenRegistryPath();
+    const registry = loadTokenRegistry();
+    const token = registry.tokens.find(token => token.token_id === tokenId);
+    if (!token) throw new Error(`Token not found: ${tokenId}`);
+
+    const next = {
+        tokens: registry.tokens.map(token => token.token_id === tokenId ? { ...token, enabled: false } : token)
+    };
+    writeFileSync(path, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    resetTenantRegistryCache();
+    console.log(`Revoked token ${tokenId}`);
+}
+
+function parseArgs(argv: string[]): Record<string, string | boolean> {
+    const args: Record<string, string | boolean> = {};
+    for (let i = 0; i < argv.length; i++) {
+        const value = argv[i];
+        if (!value.startsWith('--')) continue;
+        const eq = value.indexOf('=');
+        if (eq >= 0) {
+            args[value.slice(2, eq)] = value.slice(eq + 1);
+            continue;
+        }
+        const key = value.slice(2);
+        const next = argv[i + 1];
+        if (next && !next.startsWith('--')) {
+            args[key] = next;
+            i++;
+        } else {
+            args[key] = true;
+        }
+    }
+    return args;
+}
+
+function requireStringArg(args: Record<string, string | boolean>, key: string): string {
+    const value = args[key];
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new Error(`Missing required --${key}`);
+    }
+    return value;
+}
+
+function safeFileName(value: string): string {
+    if (!/^[a-zA-Z0-9._-]+$/.test(value)) {
+        throw new Error('Tenant ID may only contain letters, numbers, dots, underscores, and dashes');
+    }
+    return value;
+}
+
+function printUsage() {
+    console.error(`Usage:
+  search-console-mcp tenants list
+  search-console-mcp tenants validate
+  search-console-mcp tenants add --tenant=<id> --site=<siteUrl>
+  search-console-mcp tokens create --tenant=<id> [--description=<text>] [--token-id=<id>]
+  search-console-mcp tokens revoke --token-id=<id>`);
+}

--- a/src/tenant/context.ts
+++ b/src/tenant/context.ts
@@ -1,0 +1,17 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { TenantContext } from './types.js';
+
+const tenantStorage = new AsyncLocalStorage<TenantContext>();
+
+export function runWithTenant<T>(tenant: TenantContext | undefined, fn: () => T): T {
+    if (!tenant) return fn();
+    return tenantStorage.run(tenant, fn);
+}
+
+export function getCurrentTenant(): TenantContext | undefined {
+    return tenantStorage.getStore();
+}
+
+export function isTenantRequired(): boolean {
+    return process.env.MCP_REQUIRE_TENANT_TOKEN === 'true' || process.env.MCP_PRODUCTION_MODE === 'true';
+}

--- a/src/tenant/errors.ts
+++ b/src/tenant/errors.ts
@@ -1,0 +1,23 @@
+export class TenantAuthError extends Error {
+    code: 'UNAUTHORIZED' | 'FORBIDDEN' | 'NOT_FOUND';
+    status: number;
+
+    constructor(message: string, code: 'UNAUTHORIZED' | 'FORBIDDEN' | 'NOT_FOUND' = 'FORBIDDEN') {
+        super(message);
+        this.name = 'TenantAuthError';
+        this.code = code;
+        this.status = code === 'UNAUTHORIZED' ? 401 : code === 'NOT_FOUND' ? 404 : 403;
+    }
+}
+
+export function forbidden(message: string): TenantAuthError {
+    return new TenantAuthError(message, 'FORBIDDEN');
+}
+
+export function unauthorized(message: string): TenantAuthError {
+    return new TenantAuthError(message, 'UNAUTHORIZED');
+}
+
+export function notFound(message: string): TenantAuthError {
+    return new TenantAuthError(message, 'NOT_FOUND');
+}

--- a/src/tenant/guard.ts
+++ b/src/tenant/guard.ts
@@ -150,6 +150,7 @@ export function guardToolArguments(tenant: TenantContext, toolName: string, args
     if (args.feedpath) assertSitemapBelongsToAllowedSite(tenant, args.feedpath);
     if (args.sitemapUrl) assertSitemapBelongsToAllowedSite(tenant, args.sitemapUrl);
     if (Array.isArray(args.urlList)) assertBatchUrlsAllowed(tenant, args.urlList);
+    if (Array.isArray(args.urls)) assertBatchUrlsAllowed(tenant, args.urls);
 
     if (toolName === 'schema_validate' && args.type === 'url') {
         assertUrlBelongsToAllowedSite(tenant, args.data);

--- a/src/tenant/guard.ts
+++ b/src/tenant/guard.ts
@@ -150,7 +150,7 @@ export function guardToolArguments(tenant: TenantContext, toolName: string, args
     if (args.feedpath) assertSitemapBelongsToAllowedSite(tenant, args.feedpath);
     if (args.sitemapUrl) assertSitemapBelongsToAllowedSite(tenant, args.sitemapUrl);
     if (Array.isArray(args.urlList)) assertBatchUrlsAllowed(tenant, args.urlList);
-    if (Array.isArray(args.urls)) assertBatchUrlsAllowed(tenant, args.urls);
+    if (Array.isArray(args.urls) && toolName !== 'inspection_batch_inspect') assertBatchUrlsAllowed(tenant, args.urls);
 
     if (toolName === 'schema_validate' && args.type === 'url') {
         assertUrlBelongsToAllowedSite(tenant, args.data);

--- a/src/tenant/guard.ts
+++ b/src/tenant/guard.ts
@@ -150,7 +150,9 @@ export function guardToolArguments(tenant: TenantContext, toolName: string, args
     if (args.feedpath) assertSitemapBelongsToAllowedSite(tenant, args.feedpath);
     if (args.sitemapUrl) assertSitemapBelongsToAllowedSite(tenant, args.sitemapUrl);
     if (Array.isArray(args.urlList)) assertBatchUrlsAllowed(tenant, args.urlList);
-    if (Array.isArray(args.urls) && toolName !== 'inspection_batch_inspect') assertBatchUrlsAllowed(tenant, args.urls);
+    if (Array.isArray(args.urls) && !['inspection_batch_inspect', 'inspection_batch_job_start'].includes(toolName)) {
+        assertBatchUrlsAllowed(tenant, args.urls);
+    }
 
     if (toolName === 'schema_validate' && args.type === 'url') {
         assertUrlBelongsToAllowedSite(tenant, args.data);

--- a/src/tenant/guard.ts
+++ b/src/tenant/guard.ts
@@ -1,0 +1,258 @@
+import { AccountConfig, EngineType, loadConfig } from '../common/auth/config.js';
+import { normalizeWebsite, ResolutionError } from '../common/auth/resolver.js';
+import { forbidden, notFound } from './errors.js';
+import { TenantContext } from './types.js';
+
+const MUTATING_TOOLS = new Set([
+    'sites_add',
+    'sites_delete',
+    'sitemaps_submit',
+    'sitemaps_delete',
+    'bing_sites_add',
+    'bing_sites_delete',
+    'bing_sitemaps_submit',
+    'bing_sitemaps_delete',
+    'bing_url_submit',
+    'bing_url_submit_batch',
+    'bing_index_now',
+    'accounts_add_site',
+    'accounts_remove'
+]);
+
+const ADMIN_TOOLS = new Set([
+    'accounts_list',
+    'accounts_add_site',
+    'accounts_remove'
+]);
+
+export function assertToolAllowed(tenant: TenantContext, toolName: string) {
+    if (ADMIN_TOOLS.has(toolName) && !tenant.admin) {
+        throw forbidden('403 Forbidden: account management tools require an admin tenant');
+    }
+
+    if (matchesAny(toolName, tenant.deniedTools)) {
+        throw forbidden(`403 Forbidden: tool '${toolName}' is denied for this tenant`);
+    }
+
+    if (MUTATING_TOOLS.has(toolName)) {
+        if (!tenant.allowMutations || !matchesAny(toolName, tenant.allowedMutatingTools)) {
+            throw forbidden(`403 Forbidden: mutating tool '${toolName}' is disabled for this tenant`);
+        }
+    }
+
+    if (tenant.allowedTools.length > 0 && !matchesAny(toolName, tenant.allowedTools)) {
+        throw forbidden(`403 Forbidden: tool '${toolName}' is not allowed for this tenant`);
+    }
+}
+
+export function assertGoogleSiteAllowed(tenant: TenantContext, siteUrl: string) {
+    if (!tenant.engines.google) throw forbidden('403 Forbidden: google engine is not allowed for this tenant');
+    if (!isSiteAllowed(siteUrl, tenant.engines.google.allowedSites)) {
+        throw forbidden('403 Forbidden: site is not allowed for this tenant');
+    }
+}
+
+export function assertBingSiteAllowed(tenant: TenantContext, siteUrl: string) {
+    if (!tenant.engines.bing) throw forbidden('403 Forbidden: bing engine is not allowed for this tenant');
+    if (!isSiteAllowed(siteUrl, tenant.engines.bing.allowedSites)) {
+        throw forbidden('403 Forbidden: site is not allowed for this tenant');
+    }
+}
+
+export function assertGa4PropertyAllowed(tenant: TenantContext, propertyId: string) {
+    if (!tenant.engines.ga4) throw forbidden('403 Forbidden: ga4 engine is not allowed for this tenant');
+    if (!tenant.engines.ga4.allowedProperties.includes(propertyId)) {
+        throw forbidden('403 Forbidden: GA4 property is not allowed for this tenant');
+    }
+}
+
+export function assertUrlBelongsToAllowedSite(tenant: TenantContext, url: string) {
+    const allowedSites = [
+        ...(tenant.engines.google?.allowedSites || []),
+        ...(tenant.engines.bing?.allowedSites || [])
+    ];
+    if (!isUrlAllowedBySites(url, allowedSites)) {
+        throw forbidden('403 Forbidden: URL is not allowed for this tenant');
+    }
+}
+
+export function assertSitemapBelongsToAllowedSite(tenant: TenantContext, sitemapUrl: string) {
+    assertUrlBelongsToAllowedSite(tenant, sitemapUrl);
+}
+
+export function assertBatchUrlsAllowed(tenant: TenantContext, urls: string[]) {
+    if (urls.length > tenant.limits.maxBatchUrls) {
+        throw forbidden(`403 Forbidden: batch URL limit exceeded for this tenant`);
+    }
+    for (const url of urls) {
+        assertUrlBelongsToAllowedSite(tenant, url);
+    }
+}
+
+export async function resolveTenantAccount(tenant: TenantContext, siteUrl: string, engine: EngineType): Promise<AccountConfig> {
+    if (engine === 'google') assertGoogleSiteAllowed(tenant, siteUrl);
+    if (engine === 'bing') assertBingSiteAllowed(tenant, siteUrl);
+    if (engine === 'ga4') assertGa4PropertyAllowed(tenant, siteUrl);
+
+    const accountIds = engine === 'google'
+        ? tenant.engines.google?.accountIds || []
+        : engine === 'bing'
+            ? tenant.engines.bing?.accountIds || []
+            : tenant.engines.ga4?.accountIds || [];
+
+    const config = await loadConfig();
+    const accounts = accountIds
+        .map(id => config.accounts[id])
+        .filter((account): account is AccountConfig => !!account && account.engine === engine);
+
+    if (accounts.length === 0) {
+        const error = new Error(`No ${engine} accounts found for tenant '${tenant.tenantId}'.`) as ResolutionError;
+        error.code = 'NOT_FOUND';
+        throw error;
+    }
+
+    const match = accounts.find(account => accountMatchesSite(account, siteUrl, engine));
+    if (match) return match;
+
+    const error = new Error(`No ${engine} account for tenant '${tenant.tenantId}' matches '${siteUrl}'.`) as ResolutionError;
+    error.code = 'NOT_FOUND';
+    throw error;
+}
+
+export function assertAccountIdAllowed(tenant: TenantContext, accountId: string, engine: EngineType) {
+    const allowed = engine === 'google'
+        ? tenant.engines.google?.accountIds || []
+        : engine === 'bing'
+            ? tenant.engines.bing?.accountIds || []
+            : tenant.engines.ga4?.accountIds || [];
+
+    if (!allowed.includes(accountId)) {
+        throw forbidden(`403 Forbidden: account is not allowed for this tenant`);
+    }
+}
+
+export function guardToolArguments(tenant: TenantContext, toolName: string, args: any) {
+    assertToolAllowed(tenant, toolName);
+    if (!args || typeof args !== 'object') return;
+
+    const engine = args.engine as EngineType | undefined;
+    const googleSite = args.siteUrl || args.gscSiteUrl;
+    const bingSite = args.bingSiteUrl || (engine === 'bing' ? args.siteUrl : undefined);
+
+    if (googleSite && (!engine || engine === 'google')) assertGoogleSiteAllowed(tenant, googleSite);
+    if (bingSite) assertBingSiteAllowed(tenant, bingSite);
+    if (args.propertyId) assertGa4PropertyAllowed(tenant, args.propertyId);
+    if (args.ga4PropertyId) assertGa4PropertyAllowed(tenant, args.ga4PropertyId);
+    if (args.inspectionUrl) assertUrlBelongsToAllowedSite(tenant, args.inspectionUrl);
+    if (args.url) assertUrlBelongsToAllowedSite(tenant, args.url);
+    if (args.page) assertUrlBelongsToAllowedSite(tenant, args.page);
+    if (args.pageUrl) assertUrlBelongsToAllowedSite(tenant, args.pageUrl);
+    if (args.feedpath) assertSitemapBelongsToAllowedSite(tenant, args.feedpath);
+    if (args.sitemapUrl) assertSitemapBelongsToAllowedSite(tenant, args.sitemapUrl);
+    if (Array.isArray(args.urlList)) assertBatchUrlsAllowed(tenant, args.urlList);
+
+    if (toolName === 'schema_validate' && args.type === 'url') {
+        assertUrlBelongsToAllowedSite(tenant, args.data);
+    }
+
+    if (toolName === 'bing_index_now') {
+        if (args.key) {
+            throw forbidden('403 Forbidden: IndexNow key must be configured server-side for this tenant');
+        }
+        if (args.host) {
+            assertUrlBelongsToAllowedSite(tenant, `https://${args.host}/`);
+            if (Array.isArray(args.urlList)) {
+                const host = String(args.host).toLowerCase();
+                for (const url of args.urlList) {
+                    const parsed = new URL(url);
+                    if (parsed.hostname.toLowerCase() !== host) {
+                        throw forbidden('403 Forbidden: IndexNow URL host does not match requested host');
+                    }
+                }
+            }
+        }
+    }
+}
+
+export function isSiteAllowed(siteUrl: string, allowedSites: string[]): boolean {
+    if (allowedSites.length === 0) return false;
+    const normalized = normalizeWebsite(siteUrl).value;
+    return allowedSites.some(allowed => {
+        const normalizedAllowed = normalizeWebsite(allowed).value;
+        if (normalized === normalizedAllowed) return true;
+        if (normalizedAllowed.startsWith('sc-domain:')) {
+            return urlHostMatchesDomain(siteUrl, normalizedAllowed.slice('sc-domain:'.length));
+        }
+        return false;
+    });
+}
+
+export function isUrlAllowedBySites(url: string, allowedSites: string[]): boolean {
+    try {
+        const parsed = new URL(url);
+        if (!['http:', 'https:'].includes(parsed.protocol)) return false;
+        return allowedSites.some(allowed => {
+            const normalizedAllowed = normalizeWebsite(allowed).value;
+            if (normalizedAllowed.startsWith('sc-domain:')) {
+                return urlHostMatchesDomain(url, normalizedAllowed.slice('sc-domain:'.length));
+            }
+            if (!normalizedAllowed.startsWith('http://') && !normalizedAllowed.startsWith('https://')) {
+                return urlHostMatchesDomain(url, normalizedAllowed);
+            }
+            return urlMatchesPrefix(parsed, normalizedAllowed);
+        });
+    } catch {
+        return false;
+    }
+}
+
+function urlHostMatchesDomain(urlOrHost: string, domain: string): boolean {
+    const cleanDomain = domain.toLowerCase().replace(/^sc-domain:/, '');
+    try {
+        const host = new URL(urlOrHost).hostname.toLowerCase();
+        return host === cleanDomain || host.endsWith(`.${cleanDomain}`);
+    } catch {
+        const host = urlOrHost.toLowerCase().replace(/^sc-domain:/, '');
+        return host === cleanDomain;
+    }
+}
+
+function urlMatchesPrefix(parsed: URL, prefix: string): boolean {
+    try {
+        const allowed = new URL(prefix);
+        if (parsed.protocol !== allowed.protocol || parsed.hostname !== allowed.hostname) return false;
+        const allowedPath = allowed.pathname.endsWith('/') ? allowed.pathname : `${allowed.pathname}/`;
+        const actualPath = parsed.pathname.endsWith('/') ? parsed.pathname : `${parsed.pathname}/`;
+        return actualPath.startsWith(allowedPath);
+    } catch {
+        return false;
+    }
+}
+
+function accountMatchesSite(account: AccountConfig, siteUrl: string, engine: EngineType): boolean {
+    if (engine === 'ga4') {
+        return account.ga4PropertyId === siteUrl || !!account.websites?.includes(siteUrl);
+    }
+    return !!account.websites?.some(site => isSiteAllowed(siteUrl, [site]) || isUrlAllowedBySites(siteUrl, [site]));
+}
+
+function matchesAny(value: string, patterns: string[]): boolean {
+    return patterns.some(pattern => {
+        if (pattern === value || pattern === '*') return true;
+        if (pattern.endsWith('*')) return value.startsWith(pattern.slice(0, -1));
+        return false;
+    });
+}
+
+export async function tenantSitesList(tenant: TenantContext, engine: EngineType) {
+    if (engine === 'google') {
+        return [{ tenant: tenant.tenantId, engine, sites: tenant.engines.google?.allowedSites || [] }];
+    }
+    if (engine === 'bing') {
+        return [{ tenant: tenant.tenantId, engine, sites: tenant.engines.bing?.allowedSites || [] }];
+    }
+    if (engine === 'ga4') {
+        return [{ tenant: tenant.tenantId, engine, properties: tenant.engines.ga4?.allowedProperties || [] }];
+    }
+    return [];
+}

--- a/src/tenant/http.ts
+++ b/src/tenant/http.ts
@@ -7,16 +7,21 @@ import { resolveBearerToken } from './registry.js';
 import { isTenantRequired } from './context.js';
 import { sanitizeForLog } from '../utils/redaction.js';
 
-export async function startHttpServer(server: McpServer) {
+type ServerFactory = () => McpServer;
+
+interface SessionTransport {
+    server: McpServer;
+    transport: StreamableHTTPServerTransport;
+}
+
+export async function startHttpServer(serverOrFactory: McpServer | ServerFactory) {
     const host = process.env.MCP_BIND_HOST || '127.0.0.1';
     const port = Number(process.env.MCP_PORT || '3001');
     validateBindHost(host);
-
-    const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-        enableJsonResponse: true
-    });
-    await server.connect(transport);
+    const createServerInstance: ServerFactory = typeof serverOrFactory === 'function'
+        ? serverOrFactory
+        : () => serverOrFactory;
+    const sessions = new Map<string, SessionTransport>();
 
     const httpServer = createServer(async (req, res) => {
         if (!req.url?.startsWith('/mcp')) {
@@ -31,6 +36,38 @@ export async function startHttpServer(server: McpServer) {
             }
 
             const body = await readJsonBody(req);
+            const sessionId = getHeader(req, 'mcp-session-id');
+            let session = sessionId ? sessions.get(sessionId) : undefined;
+
+            if (!session) {
+                if (sessionId || !isInitializeBody(body)) {
+                    sendJson(res, 400, {
+                        jsonrpc: '2.0',
+                        error: {
+                            code: -32000,
+                            message: 'Bad Request: No valid session ID provided'
+                        },
+                        id: null
+                    });
+                    return;
+                }
+
+                const server = createServerInstance();
+                const transport = new StreamableHTTPServerTransport({
+                    sessionIdGenerator: () => randomUUID(),
+                    enableJsonResponse: true,
+                    onsessioninitialized: id => {
+                        sessions.set(id, { server, transport });
+                    }
+                });
+                transport.onclose = () => {
+                    if (transport.sessionId) sessions.delete(transport.sessionId);
+                };
+                await server.connect(transport);
+                session = { server, transport };
+            }
+
+            const transport = session.transport;
             await transport.handleRequest(req as IncomingMessage & { auth?: AuthInfo }, res, body);
         } catch (error) {
             const status = (error as any).status || 500;
@@ -48,6 +85,15 @@ export async function startHttpServer(server: McpServer) {
     await new Promise<void>((resolve) => httpServer.listen(port, host, resolve));
     console.error(`Search Console MCP Streamable HTTP listening on http://${host}:${port}/mcp`);
     return httpServer;
+}
+
+function getHeader(req: IncomingMessage, name: string): string | undefined {
+    const value = req.headers[name.toLowerCase()];
+    return Array.isArray(value) ? value[0] : value;
+}
+
+function isInitializeBody(body: unknown): boolean {
+    return !!body && typeof body === 'object' && (body as any).method === 'initialize';
 }
 
 function authenticateRequest(req: IncomingMessage): AuthInfo | undefined {

--- a/src/tenant/http.ts
+++ b/src/tenant/http.ts
@@ -12,6 +12,8 @@ type ServerFactory = () => McpServer;
 interface SessionTransport {
     server: McpServer;
     transport: StreamableHTTPServerTransport;
+    lastSeenAt: number;
+    activeRequests: number;
 }
 
 export async function startHttpServer(serverOrFactory: McpServer | ServerFactory) {
@@ -22,6 +24,7 @@ export async function startHttpServer(serverOrFactory: McpServer | ServerFactory
         ? serverOrFactory
         : () => serverOrFactory;
     const sessions = new Map<string, SessionTransport>();
+    const sessionTtlMs = getSessionTtlMs();
 
     const httpServer = createServer(async (req, res) => {
         if (!req.url?.startsWith('/mcp')) {
@@ -30,6 +33,7 @@ export async function startHttpServer(serverOrFactory: McpServer | ServerFactory
         }
 
         try {
+            await cleanupExpiredSessions(sessions, sessionTtlMs);
             const auth = authenticateRequest(req);
             if (auth) {
                 (req as IncomingMessage & { auth?: AuthInfo }).auth = auth;
@@ -57,18 +61,32 @@ export async function startHttpServer(serverOrFactory: McpServer | ServerFactory
                     sessionIdGenerator: () => randomUUID(),
                     enableJsonResponse: true,
                     onsessioninitialized: id => {
-                        sessions.set(id, { server, transport });
+                        sessions.set(id, { server, transport, lastSeenAt: Date.now(), activeRequests: 0 });
                     }
                 });
                 transport.onclose = () => {
                     if (transport.sessionId) sessions.delete(transport.sessionId);
                 };
                 await server.connect(transport);
-                session = { server, transport };
+                session = { server, transport, lastSeenAt: Date.now(), activeRequests: 0 };
             }
 
             const transport = session.transport;
-            await transport.handleRequest(req as IncomingMessage & { auth?: AuthInfo }, res, body);
+            session.lastSeenAt = Date.now();
+            session.activeRequests += 1;
+            try {
+                await transport.handleRequest(req as IncomingMessage & { auth?: AuthInfo }, res, body);
+            } finally {
+                session.activeRequests = Math.max(0, session.activeRequests - 1);
+                session.lastSeenAt = Date.now();
+                if (transport.sessionId) {
+                    const stored = sessions.get(transport.sessionId);
+                    if (stored) {
+                        stored.lastSeenAt = session.lastSeenAt;
+                        stored.activeRequests = session.activeRequests;
+                    }
+                }
+            }
         } catch (error) {
             const status = (error as any).status || 500;
             sendJson(res, status, {
@@ -85,6 +103,26 @@ export async function startHttpServer(serverOrFactory: McpServer | ServerFactory
     await new Promise<void>((resolve) => httpServer.listen(port, host, resolve));
     console.error(`Search Console MCP Streamable HTTP listening on http://${host}:${port}/mcp`);
     return httpServer;
+}
+
+async function cleanupExpiredSessions(sessions: Map<string, SessionTransport>, sessionTtlMs: number) {
+    const now = Date.now();
+    for (const [id, session] of sessions) {
+        if (session.activeRequests > 0) continue;
+        if (now - session.lastSeenAt <= sessionTtlMs) continue;
+        sessions.delete(id);
+        try {
+            await session.transport.close();
+        } catch {
+            // Best-effort cleanup; a failed close should not break unrelated requests.
+        }
+    }
+}
+
+function getSessionTtlMs() {
+    const fallback = 30 * 60 * 1000;
+    const configured = Number(process.env.MCP_HTTP_SESSION_TTL_MS || fallback);
+    return Number.isFinite(configured) && configured > 0 ? configured : fallback;
 }
 
 function getHeader(req: IncomingMessage, name: string): string | undefined {

--- a/src/tenant/http.ts
+++ b/src/tenant/http.ts
@@ -1,0 +1,104 @@
+import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { resolveBearerToken } from './registry.js';
+import { isTenantRequired } from './context.js';
+import { sanitizeForLog } from '../utils/redaction.js';
+
+export async function startHttpServer(server: McpServer) {
+    const host = process.env.MCP_BIND_HOST || '127.0.0.1';
+    const port = Number(process.env.MCP_PORT || '3001');
+    validateBindHost(host);
+
+    const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true
+    });
+    await server.connect(transport);
+
+    const httpServer = createServer(async (req, res) => {
+        if (!req.url?.startsWith('/mcp')) {
+            sendJson(res, 404, { error: 'Not found' });
+            return;
+        }
+
+        try {
+            const auth = authenticateRequest(req);
+            if (auth) {
+                (req as IncomingMessage & { auth?: AuthInfo }).auth = auth;
+            }
+
+            const body = await readJsonBody(req);
+            await transport.handleRequest(req as IncomingMessage & { auth?: AuthInfo }, res, body);
+        } catch (error) {
+            const status = (error as any).status || 500;
+            sendJson(res, status, {
+                jsonrpc: '2.0',
+                error: {
+                    code: status === 401 ? -32001 : status === 403 ? -32003 : -32603,
+                    message: sanitizeForLog((error as Error).message || 'Internal server error')
+                },
+                id: null
+            });
+        }
+    });
+
+    await new Promise<void>((resolve) => httpServer.listen(port, host, resolve));
+    console.error(`Search Console MCP Streamable HTTP listening on http://${host}:${port}/mcp`);
+    return httpServer;
+}
+
+function authenticateRequest(req: IncomingMessage): AuthInfo | undefined {
+    const header = req.headers.authorization;
+    if (!header) {
+        if (isTenantRequired()) {
+            const err = new Error('Missing Authorization bearer token') as any;
+            err.status = 401;
+            throw err;
+        }
+        return undefined;
+    }
+
+    const match = /^Bearer\s+(.+)$/i.exec(header);
+    if (!match) {
+        const err = new Error('Invalid Authorization header') as any;
+        err.status = 401;
+        throw err;
+    }
+
+    const { token, tenant } = resolveBearerToken(match[1]);
+    return {
+        token: token.token_id,
+        clientId: tenant.tenantId,
+        scopes: tenant.allowedTools,
+        extra: { tenantContext: tenant, tokenId: token.token_id }
+    };
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+    if (req.method === 'GET' || req.method === 'DELETE') return undefined;
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const raw = Buffer.concat(chunks).toString('utf8');
+    if (!raw) return undefined;
+    return JSON.parse(raw);
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown) {
+    if (res.headersSent) return;
+    res.writeHead(status, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(body));
+}
+
+function validateBindHost(host: string) {
+    const production = process.env.MCP_PRODUCTION_MODE === 'true';
+    if (!production) return;
+
+    const allowedPublic = process.env.MCP_ALLOW_PUBLIC_BIND === 'true';
+    if ((host === '0.0.0.0' || host === '::') && !allowedPublic) {
+        throw new Error('Refusing public bind host in production without MCP_ALLOW_PUBLIC_BIND=true');
+    }
+}

--- a/src/tenant/http.ts
+++ b/src/tenant/http.ts
@@ -6,6 +6,7 @@ import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { resolveBearerToken } from './registry.js';
 import { isTenantRequired } from './context.js';
 import { sanitizeForLog } from '../utils/redaction.js';
+import { logger } from '../utils/logger.js';
 
 type ServerFactory = () => McpServer;
 
@@ -25,6 +26,13 @@ export async function startHttpServer(serverOrFactory: McpServer | ServerFactory
         : () => serverOrFactory;
     const sessions = new Map<string, SessionTransport>();
     const sessionTtlMs = getSessionTtlMs();
+    const maxSessions = getMaxSessions();
+    const cleanupInterval = setInterval(() => {
+        cleanupExpiredSessions(sessions, sessionTtlMs).catch(error => {
+            logger.warn('HTTP session cleanup failed', { error: sanitizeForLog(error) });
+        });
+    }, getSessionCleanupIntervalMs(sessionTtlMs));
+    cleanupInterval.unref?.();
 
     const httpServer = createServer(async (req, res) => {
         if (!req.url?.startsWith('/mcp')) {
@@ -56,16 +64,41 @@ export async function startHttpServer(serverOrFactory: McpServer | ServerFactory
                     return;
                 }
 
+                if (sessions.size >= maxSessions) {
+                    logger.warn('HTTP session limit reached', {
+                        activeSessions: sessions.size,
+                        maxSessions
+                    });
+                    sendJson(res, 503, {
+                        jsonrpc: '2.0',
+                        error: {
+                            code: -32000,
+                            message: 'Service Unavailable: too many active MCP sessions'
+                        },
+                        id: null
+                    });
+                    return;
+                }
+
                 const server = createServerInstance();
                 const transport = new StreamableHTTPServerTransport({
                     sessionIdGenerator: () => randomUUID(),
                     enableJsonResponse: true,
                     onsessioninitialized: id => {
                         sessions.set(id, { server, transport, lastSeenAt: Date.now(), activeRequests: 0 });
+                        logger.info('HTTP session created', {
+                            activeSessions: sessions.size,
+                            maxSessions
+                        });
                     }
                 });
                 transport.onclose = () => {
-                    if (transport.sessionId) sessions.delete(transport.sessionId);
+                    if (transport.sessionId && sessions.delete(transport.sessionId)) {
+                        logger.info('HTTP session closed', {
+                            activeSessions: sessions.size,
+                            maxSessions
+                        });
+                    }
                 };
                 await server.connect(transport);
                 session = { server, transport, lastSeenAt: Date.now(), activeRequests: 0 };
@@ -86,6 +119,9 @@ export async function startHttpServer(serverOrFactory: McpServer | ServerFactory
                         stored.activeRequests = session.activeRequests;
                     }
                 }
+                if (req.method === 'DELETE' && transport.sessionId) {
+                    await closeAndDeleteSession(sessions, transport.sessionId, 'deleted', maxSessions);
+                }
             }
         } catch (error) {
             const status = (error as any).status || 500;
@@ -100,6 +136,16 @@ export async function startHttpServer(serverOrFactory: McpServer | ServerFactory
         }
     });
 
+    httpServer.on('close', () => {
+        clearInterval(cleanupInterval);
+        for (const [id, session] of sessions) {
+            sessions.delete(id);
+            session.transport.close().catch(() => {
+                // Best-effort shutdown cleanup.
+            });
+        }
+    });
+
     await new Promise<void>((resolve) => httpServer.listen(port, host, resolve));
     console.error(`Search Console MCP Streamable HTTP listening on http://${host}:${port}/mcp`);
     return httpServer;
@@ -107,22 +153,57 @@ export async function startHttpServer(serverOrFactory: McpServer | ServerFactory
 
 async function cleanupExpiredSessions(sessions: Map<string, SessionTransport>, sessionTtlMs: number) {
     const now = Date.now();
+    let expired = 0;
     for (const [id, session] of sessions) {
         if (session.activeRequests > 0) continue;
         if (now - session.lastSeenAt <= sessionTtlMs) continue;
-        sessions.delete(id);
-        try {
-            await session.transport.close();
-        } catch {
-            // Best-effort cleanup; a failed close should not break unrelated requests.
-        }
+        await closeAndDeleteSession(sessions, id, 'expired');
+        expired++;
     }
+    if (expired > 0) {
+        logger.info('HTTP sessions expired', {
+            expiredSessions: expired,
+            activeSessions: sessions.size
+        });
+    }
+}
+
+async function closeAndDeleteSession(
+    sessions: Map<string, SessionTransport>,
+    id: string,
+    reason: 'expired' | 'deleted',
+    maxSessions?: number
+) {
+    const session = sessions.get(id);
+    if (!session) return;
+    sessions.delete(id);
+    try {
+        await session.transport.close();
+    } catch {
+        // Best-effort cleanup; a failed close should not break unrelated requests.
+    }
+    logger.info('HTTP session removed', {
+        reason,
+        activeSessions: sessions.size,
+        ...(maxSessions ? { maxSessions } : {})
+    });
 }
 
 function getSessionTtlMs() {
     const fallback = 30 * 60 * 1000;
     const configured = Number(process.env.MCP_HTTP_SESSION_TTL_MS || fallback);
     return Number.isFinite(configured) && configured > 0 ? configured : fallback;
+}
+
+function getSessionCleanupIntervalMs(sessionTtlMs: number) {
+    const fallback = Math.min(60 * 1000, Math.max(1_000, Math.floor(sessionTtlMs / 2)));
+    const configured = Number(process.env.MCP_HTTP_SESSION_CLEANUP_INTERVAL_MS || fallback);
+    return Number.isFinite(configured) && configured > 0 ? configured : fallback;
+}
+
+function getMaxSessions() {
+    const configured = Number(process.env.MCP_HTTP_MAX_SESSIONS || 100);
+    return Number.isFinite(configured) && configured > 0 ? Math.floor(configured) : 100;
 }
 
 function getHeader(req: IncomingMessage, name: string): string | undefined {

--- a/src/tenant/http.ts
+++ b/src/tenant/http.ts
@@ -1,4 +1,5 @@
 import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
@@ -12,7 +13,7 @@ export async function startHttpServer(server: McpServer) {
     validateBindHost(host);
 
     const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
+        sessionIdGenerator: () => randomUUID(),
         enableJsonResponse: true
     });
     await server.connect(transport);

--- a/src/tenant/registry.ts
+++ b/src/tenant/registry.ts
@@ -1,0 +1,120 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { TenantConfigSchema, TokenRegistrySchema, TenantContext, TokenRecord, toTenantContext } from './types.js';
+import { unauthorized } from './errors.js';
+
+let cachedTenants: Map<string, TenantContext> | null = null;
+let cachedTokenRegistry: ReturnType<typeof TokenRegistrySchema.parse> | null = null;
+
+export function resetTenantRegistryCache() {
+    cachedTenants = null;
+    cachedTokenRegistry = null;
+}
+
+export function getTenantsDir(): string {
+    return process.env.MCP_TENANTS_DIR || '/etc/search-console-mcp/tenants';
+}
+
+export function getTokenRegistryPath(): string {
+    return process.env.MCP_TOKEN_REGISTRY || '/etc/search-console-mcp/tokens/tokens.json';
+}
+
+export function hashBearerToken(token: string): string {
+    return `sha256:${createHash('sha256').update(token).digest('hex')}`;
+}
+
+export function generateBearerToken(): string {
+    return `scmcp_${randomBytes(32).toString('base64url')}`;
+}
+
+export function loadTenants(): Map<string, TenantContext> {
+    if (cachedTenants) return cachedTenants;
+
+    const tenants = new Map<string, TenantContext>();
+    const dir = getTenantsDir();
+    if (!existsSync(dir)) {
+        cachedTenants = tenants;
+        return tenants;
+    }
+
+    for (const file of readdirSync(dir)) {
+        if (!file.endsWith('.json')) continue;
+        const raw = JSON.parse(readFileSync(join(dir, file), 'utf8'));
+        const parsed = TenantConfigSchema.parse(raw);
+        const context = toTenantContext(parsed);
+        tenants.set(context.tenantId, context);
+    }
+
+    cachedTenants = tenants;
+    return tenants;
+}
+
+export function loadTokenRegistry() {
+    if (cachedTokenRegistry) return cachedTokenRegistry;
+
+    const path = getTokenRegistryPath();
+    if (!existsSync(path)) {
+        cachedTokenRegistry = { tokens: [] };
+        return cachedTokenRegistry;
+    }
+
+    cachedTokenRegistry = TokenRegistrySchema.parse(JSON.parse(readFileSync(path, 'utf8')));
+    return cachedTokenRegistry;
+}
+
+export function resolveBearerToken(token: string): { token: TokenRecord; tenant: TenantContext } {
+    const hash = hashBearerToken(token);
+    const tokenRecord = loadTokenRegistry().tokens.find(t => t.token_hash === hash);
+
+    if (!tokenRecord || !tokenRecord.enabled) {
+        throw unauthorized('Invalid or disabled bearer token');
+    }
+
+    const tenant = loadTenants().get(tokenRecord.tenant_id);
+    if (!tenant) {
+        throw unauthorized('Bearer token tenant does not exist');
+    }
+
+    if (!isEnabledTenant(tenant)) {
+        throw unauthorized('Bearer token tenant is disabled');
+    }
+
+    return { token: tokenRecord, tenant };
+}
+
+function isEnabledTenant(tenant: TenantContext): boolean {
+    const raw = loadRawTenant(tenant.tenantId);
+    return raw?.enabled !== false;
+}
+
+function loadRawTenant(tenantId: string): { enabled?: boolean } | null {
+    const path = join(getTenantsDir(), `${tenantId}.json`);
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+export function createTokenRecord(tenantId: string, description?: string, tokenId?: string): { plaintext: string; record: TokenRecord } {
+    const plaintext = generateBearerToken();
+    const id = tokenId || `${tenantId}-${Date.now()}`;
+    return {
+        plaintext,
+        record: {
+            token_id: id,
+            tenant_id: tenantId,
+            token_hash: hashBearerToken(plaintext),
+            enabled: true,
+            created_at: new Date().toISOString(),
+            description
+        }
+    };
+}
+
+export function appendTokenRecord(record: TokenRecord) {
+    const path = getTokenRegistryPath();
+    const registry = loadTokenRegistry();
+    const next = { tokens: [...registry.tokens, record] };
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(next, null, 2), { mode: 0o600 });
+    cachedTokenRegistry = next;
+}

--- a/src/tenant/tool-guard.ts
+++ b/src/tenant/tool-guard.ts
@@ -1,0 +1,80 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { isTenantRequired, runWithTenant } from './context.js';
+import { unauthorized } from './errors.js';
+import { guardToolArguments, tenantSitesList } from './guard.js';
+import { TenantContext } from './types.js';
+
+type AnyFunction = (...args: any[]) => any;
+
+export function installTenantGuard(server: McpServer) {
+    const anyServer = server as any;
+    const originalTool = anyServer.tool.bind(server);
+    const originalRegisterTool = anyServer.registerTool.bind(server);
+    const originalResource = anyServer.resource.bind(server);
+
+    anyServer.tool = (...args: any[]) => {
+        return originalTool(...wrapRegistrationArgs(args));
+    };
+
+    anyServer.registerTool = (name: string, config: any, cb: AnyFunction) => {
+        return originalRegisterTool(name, config, wrapToolCallback(name, cb));
+    };
+
+    anyServer.resource = (...args: any[]) => {
+        const callbackIndex = args.findIndex(arg => typeof arg === 'function');
+        if (callbackIndex >= 0) {
+            const cb = args[callbackIndex];
+            args[callbackIndex] = (...cbArgs: any[]) => {
+                const extra = cbArgs[cbArgs.length - 1];
+                const tenant = getTenantFromExtra(extra);
+                if (isTenantRequired() && tenant) {
+                    throw unauthorized('Resources are not available in tenant HTTP mode');
+                }
+                if (isTenantRequired() && !tenant) {
+                    throw unauthorized('Missing tenant context');
+                }
+                return runWithTenant(tenant, () => cb(...cbArgs));
+            };
+        }
+        return originalResource(...args);
+    };
+}
+
+function wrapRegistrationArgs(args: any[]): any[] {
+    const name = args[0];
+    const callbackIndex = args.findIndex((arg, index) => index > 0 && typeof arg === 'function');
+    if (typeof name === 'string' && callbackIndex >= 0) {
+        args[callbackIndex] = wrapToolCallback(name, args[callbackIndex]);
+    }
+    return args;
+}
+
+function wrapToolCallback(toolName: string, cb: AnyFunction): AnyFunction {
+    return async (...args: any[]) => {
+        const extra = args[args.length - 1];
+        const tenant = getTenantFromExtra(extra);
+
+        if (isTenantRequired() && !tenant) {
+            throw unauthorized('Missing tenant context');
+        }
+
+        if (!tenant) {
+            return cb(...args);
+        }
+
+        const toolArgs = args.length > 1 ? args[0] : {};
+        guardToolArguments(tenant, toolName, toolArgs);
+
+        if (toolName === 'sites_list') {
+            const engine = (toolArgs.engine || 'google') as any;
+            const results = await tenantSitesList(tenant, engine);
+            return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
+        }
+
+        return runWithTenant(tenant, () => cb(...args));
+    };
+}
+
+function getTenantFromExtra(extra: any): TenantContext | undefined {
+    return extra?.authInfo?.extra?.tenantContext as TenantContext | undefined;
+}

--- a/src/tenant/types.ts
+++ b/src/tenant/types.ts
@@ -1,0 +1,131 @@
+import { z } from 'zod';
+
+export const EnginePolicySchema = z.object({
+    account_ids: z.array(z.string()).default([]),
+    allowed_sites: z.array(z.string()).default([]),
+    default_site: z.string().optional()
+});
+
+export const GA4PolicySchema = z.object({
+    account_ids: z.array(z.string()).default([]),
+    allowed_properties: z.array(z.string()).default([])
+});
+
+export const TenantConfigSchema = z.object({
+    tenant_id: z.string().min(1),
+    display_name: z.string().min(1),
+    enabled: z.boolean().default(true),
+    admin: z.boolean().optional().default(false),
+    engines: z.object({
+        google: EnginePolicySchema.optional(),
+        bing: EnginePolicySchema.optional(),
+        ga4: GA4PolicySchema.optional()
+    }).default({}),
+    allowed_tools: z.array(z.string()).default([]),
+    denied_tools: z.array(z.string()).default([]),
+    allow_mutations: z.boolean().optional().default(false),
+    allowed_mutating_tools: z.array(z.string()).optional().default([]),
+    limits: z.object({
+        max_rows: z.number().int().positive().default(25000),
+        max_batch_urls: z.number().int().positive().default(10),
+        request_timeout_seconds: z.number().int().positive().default(120)
+    }).default({
+        max_rows: 25000,
+        max_batch_urls: 10,
+        request_timeout_seconds: 120
+    }),
+    indexnow: z.object({
+        keys: z.record(z.string(), z.object({
+            key: z.string(),
+            key_location: z.string().optional()
+        })).default({})
+    }).optional()
+});
+
+export const TokenRecordSchema = z.object({
+    token_id: z.string().min(1),
+    tenant_id: z.string().min(1),
+    token_hash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    enabled: z.boolean().default(true),
+    created_at: z.string().optional(),
+    description: z.string().optional()
+});
+
+export const TokenRegistrySchema = z.object({
+    tokens: z.array(TokenRecordSchema).default([])
+});
+
+export type TenantConfig = z.infer<typeof TenantConfigSchema>;
+export type TokenRecord = z.infer<typeof TokenRecordSchema>;
+export type TokenRegistry = z.infer<typeof TokenRegistrySchema>;
+
+export interface TenantContext {
+    tenantId: string;
+    displayName: string;
+    admin: boolean;
+    allowedTools: string[];
+    deniedTools: string[];
+    allowMutations: boolean;
+    allowedMutatingTools: string[];
+    engines: {
+        google?: {
+            accountIds: string[];
+            allowedSites: string[];
+            defaultSite?: string;
+        };
+        bing?: {
+            accountIds: string[];
+            allowedSites: string[];
+            defaultSite?: string;
+        };
+        ga4?: {
+            accountIds: string[];
+            allowedProperties: string[];
+        };
+    };
+    limits: {
+        maxRows: number;
+        maxBatchUrls: number;
+        requestTimeoutSeconds: number;
+    };
+    indexNowKeys: Record<string, { key: string; keyLocation?: string }>;
+}
+
+export function toTenantContext(config: TenantConfig): TenantContext {
+    return {
+        tenantId: config.tenant_id,
+        displayName: config.display_name,
+        admin: !!config.admin,
+        allowedTools: config.allowed_tools,
+        deniedTools: config.denied_tools,
+        allowMutations: !!config.allow_mutations,
+        allowedMutatingTools: config.allowed_mutating_tools || [],
+        engines: {
+            google: config.engines.google ? {
+                accountIds: config.engines.google.account_ids,
+                allowedSites: config.engines.google.allowed_sites,
+                defaultSite: config.engines.google.default_site
+            } : undefined,
+            bing: config.engines.bing ? {
+                accountIds: config.engines.bing.account_ids,
+                allowedSites: config.engines.bing.allowed_sites,
+                defaultSite: config.engines.bing.default_site
+            } : undefined,
+            ga4: config.engines.ga4 ? {
+                accountIds: config.engines.ga4.account_ids,
+                allowedProperties: config.engines.ga4.allowed_properties
+            } : undefined
+        },
+        limits: {
+            maxRows: config.limits.max_rows,
+            maxBatchUrls: config.limits.max_batch_urls,
+            requestTimeoutSeconds: config.limits.request_timeout_seconds
+        },
+        indexNowKeys: Object.fromEntries(
+            Object.entries(config.indexnow?.keys || {}).map(([host, value]) => [
+                host.toLowerCase(),
+                { key: value.key, keyLocation: value.key_location }
+            ])
+        )
+    };
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,6 +5,7 @@
  */
 
 import { colors } from './ui.js';
+import { sanitizeArgs, sanitizeForLog } from './redaction.js';
 
 const isDebugEnabled = process.env.DEBUG === 'true' || process.env.NODE_ENV === 'development';
 
@@ -16,8 +17,8 @@ export const logger = {
         if (isDebugEnabled) {
             const timestamp = new Date().toISOString();
             console.error(
-                `${colors.dim}[${timestamp}]${colors.reset} ${colors.blue}[DEBUG]${colors.reset} ${message}`,
-                ...args
+                `${colors.dim}[${timestamp}]${colors.reset} ${colors.blue}[DEBUG]${colors.reset} ${sanitizeForLog(message)}`,
+                ...sanitizeArgs(args)
             );
         }
     },
@@ -28,8 +29,8 @@ export const logger = {
     error(message: string, error?: any) {
         const timestamp = new Date().toISOString();
         console.error(
-            `${colors.dim}[${timestamp}]${colors.reset} ${colors.red}[ERROR]${colors.reset} ${message}`,
-            error || ''
+            `${colors.dim}[${timestamp}]${colors.reset} ${colors.red}[ERROR]${colors.reset} ${sanitizeForLog(message)}`,
+            error ? sanitizeForLog(error) : ''
         );
     },
 
@@ -39,8 +40,8 @@ export const logger = {
     info(message: string, ...args: any[]) {
         const timestamp = new Date().toISOString();
         console.error(
-            `${colors.dim}[${timestamp}]${colors.reset} ${colors.green}[INFO]${colors.reset} ${message}`,
-            ...args
+            `${colors.dim}[${timestamp}]${colors.reset} ${colors.green}[INFO]${colors.reset} ${sanitizeForLog(message)}`,
+            ...sanitizeArgs(args)
         );
     },
 
@@ -50,8 +51,8 @@ export const logger = {
     warn(message: string, ...args: any[]) {
         const timestamp = new Date().toISOString();
         console.error(
-            `${colors.dim}[${timestamp}]${colors.reset} ${colors.yellow}[WARN]${colors.reset} ${message}`,
-            ...args
+            `${colors.dim}[${timestamp}]${colors.reset} ${colors.yellow}[WARN]${colors.reset} ${sanitizeForLog(message)}`,
+            ...sanitizeArgs(args)
         );
     }
 };

--- a/src/utils/redaction.ts
+++ b/src/utils/redaction.ts
@@ -1,0 +1,22 @@
+const REDACTION_PATTERNS: RegExp[] = [
+    /Bearer\s+[A-Za-z0-9._~+/=-]{8,}/gi,
+    /(apikey=)[^&\s]+/gi,
+    /((?:api[_-]?key|token|refresh[_-]?token|access[_-]?token|client[_-]?secret|private[_-]?key)["']?\s*[:=]\s*["']?)[^"',\s}]+/gi,
+    /sha256:[a-f0-9]{64}/gi,
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g
+];
+
+export function sanitizeForLog(value: unknown): string {
+    let text = value instanceof Error ? value.message : typeof value === 'string' ? value : JSON.stringify(value);
+    if (!text) return '';
+    for (const pattern of REDACTION_PATTERNS) {
+        text = text.replace(pattern, (_match, prefix) =>
+            typeof prefix === 'string' && prefix.length > 0 ? `${prefix}[REDACTED]` : '[REDACTED]'
+        );
+    }
+    return text;
+}
+
+export function sanitizeArgs(args: unknown[]): string[] {
+    return args.map(arg => sanitizeForLog(arg));
+}

--- a/tests/analytics-advanced.test.ts
+++ b/tests/analytics-advanced.test.ts
@@ -167,11 +167,14 @@ describe('getPerformanceByCountry', () => {
         expect(result.items.length).toBe(2);
         expect(result.items[0].key).toBe('USA');
         expect(result.items[0].clicks).toBe(100);
-        expect(mockSearchConsoleClient.searchanalytics.query).toHaveBeenCalledWith(expect.objectContaining({
-            requestBody: expect.objectContaining({
-                dimensions: ['country']
-            })
-        }));
+        expect(mockSearchConsoleClient.searchanalytics.query).toHaveBeenCalledWith(
+            expect.objectContaining({
+                requestBody: expect.objectContaining({
+                    dimensions: ['country']
+                })
+            }),
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 });
 
@@ -193,11 +196,13 @@ describe('getPerformanceBySearchAppearance', () => {
 
         expect(result.items.length).toBe(1);
         expect(result.items[0].key).toBe('AMP_BLUE_LINK');
-        expect(mockSearchConsoleClient.searchanalytics.query).toHaveBeenCalledWith(expect.objectContaining({
-            requestBody: expect.objectContaining({
-                dimensions: ['searchAppearance']
-            })
-        }));
+        expect(mockSearchConsoleClient.searchanalytics.query).toHaveBeenCalledWith(
+            expect.objectContaining({
+                requestBody: expect.objectContaining({
+                    dimensions: ['searchAppearance']
+                })
+            }),
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 });
-

--- a/tests/google-upstream.test.ts
+++ b/tests/google-upstream.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getGoogleApiTimeoutMs, runGoogleApiCall } from '../src/google/upstream.js';
+
+describe('Google upstream timeout handling', () => {
+  afterEach(() => {
+    delete process.env.MCP_GOOGLE_API_TIMEOUT_MS;
+    vi.restoreAllMocks();
+  });
+
+  it('uses explicit environment timeout when configured', () => {
+    process.env.MCP_GOOGLE_API_TIMEOUT_MS = '45000';
+    expect(getGoogleApiTimeoutMs()).toBe(45000);
+  });
+
+  it('falls back to tenant request timeout when no override is configured', () => {
+    expect(getGoogleApiTimeoutMs({
+      tenantId: 'tenant-a',
+      displayName: 'Tenant A',
+      admin: false,
+      allowedTools: [],
+      deniedTools: [],
+      allowMutations: false,
+      allowedMutatingTools: [],
+      engines: {},
+      limits: {
+        maxRows: 100,
+        maxBatchUrls: 10,
+        requestTimeoutSeconds: 42
+      },
+      indexNowKeys: {}
+    })).toBe(42000);
+  });
+
+  it('passes timeout options to wrapped provider call', async () => {
+    process.env.MCP_GOOGLE_API_TIMEOUT_MS = '12345';
+    const call = vi.fn().mockResolvedValue('ok');
+
+    const result = await runGoogleApiCall('test.operation', call);
+
+    expect(result).toBe('ok');
+    expect(call).toHaveBeenCalledWith({ timeout: 12345 });
+  });
+});

--- a/tests/inspection-cache.test.ts
+++ b/tests/inspection-cache.test.ts
@@ -85,6 +85,7 @@ describe('URL Inspection cache layer', () => {
         const normalized = normalizeInspectionResponse('sc-domain:a.example', 'https://a.example/page', rawInspection as any);
 
         expect(normalized).toMatchObject({
+            url: 'https://a.example/page',
             inspectionUrl: 'https://a.example/page',
             siteUrl: 'sc-domain:a.example',
             verdict: 'PASS',
@@ -108,6 +109,8 @@ describe('URL Inspection cache layer', () => {
 
         const second = await inspectUrlNormalized('sc-domain:a.example', 'https://a.example/page', 'en-US', tenant);
         expect(second.metadata).toMatchObject({ cacheHit: true, apiCallMade: false, quotaUnitEstimate: 0 });
+        expect(second.metadata.cachedAt).toBeTruthy();
+        expect(typeof second.metadata.cacheAgeHours).toBe('number');
         expect(inspectMock).toHaveBeenCalledTimes(1);
 
         const cached = readFreshInspectionCache('tenant-a', 'sc-domain:a.example', 'https://a.example/page');
@@ -135,7 +138,56 @@ describe('URL Inspection cache layer', () => {
             quotaLimited: 1,
             quotaUnitEstimate: 2
         });
-        expect(result.results.map((row: any) => row.status)).toEqual(['ok', 'error', 'quota_limited']);
+        expect(result.results.map((row: any) => row.status)).toEqual(['ok', 'provider_error', 'quota_limited']);
+    });
+
+    it('returns per-URL invalid and forbidden statuses without calling Google', async () => {
+        const result = await inspectBatchWithCache('sc-domain:a.example', [
+            'not-a-url',
+            'https://b.example/page',
+            'https://a.example/page'
+        ], tenant, {
+            cacheMode: 'bypass',
+            maxApiCallsPerRun: 5
+        });
+
+        expect(result.summary).toMatchObject({
+            requested: 3,
+            apiCallsMade: 1,
+            invalidUrls: 1,
+            forbiddenUrls: 1
+        });
+        expect(result.results.map((row: any) => row.status)).toEqual(['invalid_url', 'forbidden_url', 'ok']);
+        expect(inspectMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports read_only cache mode without provider calls on cache miss', async () => {
+        const result = await inspectBatchWithCache('sc-domain:a.example', [
+            'https://a.example/missing'
+        ], tenant, {
+            cacheMode: 'read_only'
+        });
+
+        expect(result.results[0]).toMatchObject({
+            status: 'provider_error',
+            errorCode: 'CACHE_MISS_READ_ONLY',
+            metadata: {
+                cacheHit: false,
+                apiCallMade: false,
+                quotaUnitEstimate: 0
+            }
+        });
+        expect(inspectMock).not.toHaveBeenCalled();
+    });
+
+    it('bypasses cache without writing unless forceRefresh requests a fresh write', async () => {
+        await inspectUrlNormalized('sc-domain:a.example', 'https://a.example/bypass', 'en-US', tenant, { cacheMode: 'bypass' });
+        await inspectUrlNormalized('sc-domain:a.example', 'https://a.example/bypass', 'en-US', tenant, { cacheMode: 'bypass' });
+        expect(inspectMock).toHaveBeenCalledTimes(2);
+
+        await inspectUrlNormalized('sc-domain:a.example', 'https://a.example/refresh', 'en-US', tenant, { cacheMode: 'bypass', forceRefresh: true });
+        const cached = readFreshInspectionCache('tenant-a', 'sc-domain:a.example', 'https://a.example/refresh');
+        expect(cached?.entry.normalized?.coverageState).toBe('Submitted and indexed');
     });
 
     it('reports cache stats for Paperclip consumers', async () => {

--- a/tests/inspection-cache.test.ts
+++ b/tests/inspection-cache.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { TenantContext } from '../src/tenant/types.js';
+import {
+    getInspectionCacheStats,
+    normalizeInspectionResponse,
+    readFreshInspectionCache
+} from '../src/google/tools/inspection-cache.js';
+import {
+    inspectBatchWithCache,
+    inspectUrlNormalized
+} from '../src/google/tools/inspection.js';
+import { getSearchConsoleClient } from '../src/google/client.js';
+
+vi.mock('../src/google/client.js', () => ({
+    getSearchConsoleClient: vi.fn()
+}));
+
+const tenant: TenantContext = {
+    tenantId: 'tenant-a',
+    displayName: 'Tenant A',
+    admin: false,
+    allowedTools: ['inspection_*'],
+    deniedTools: [],
+    allowMutations: false,
+    allowedMutatingTools: [],
+    engines: {
+        google: {
+            accountIds: ['google_a'],
+            allowedSites: ['sc-domain:a.example']
+        }
+    },
+    limits: {
+        maxRows: 100,
+        maxBatchUrls: 10,
+        requestTimeoutSeconds: 30
+    },
+    indexNowKeys: {}
+};
+
+const rawInspection = {
+    inspectionResult: {
+        inspectionResultLink: 'https://search.google.com/search-console/inspect',
+        indexStatusResult: {
+            verdict: 'PASS',
+            coverageState: 'Submitted and indexed',
+            indexingState: 'INDEXING_ALLOWED',
+            lastCrawlTime: '2026-05-25T10:00:00Z',
+            pageFetchState: 'SUCCESSFUL',
+            robotsTxtState: 'ALLOWED',
+            googleCanonical: 'https://a.example/page',
+            userCanonical: 'https://a.example/page',
+            referringUrls: ['https://a.example/'],
+            sitemap: ['https://a.example/sitemap.xml']
+        }
+    }
+};
+
+describe('URL Inspection cache layer', () => {
+    let tempDir: string;
+    let inspectMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        tempDir = mkdtempSync(join(tmpdir(), 'inspection-cache-'));
+        process.env.MCP_INSPECTION_CACHE_DIR = tempDir;
+        inspectMock = vi.fn().mockResolvedValue({ data: rawInspection });
+        vi.mocked(getSearchConsoleClient).mockResolvedValue({
+            urlInspection: {
+                index: {
+                    inspect: inspectMock
+                }
+            }
+        } as any);
+    });
+
+    afterEach(() => {
+        delete process.env.MCP_INSPECTION_CACHE_DIR;
+        rmSync(tempDir, { recursive: true, force: true });
+        vi.clearAllMocks();
+    });
+
+    it('normalizes URL Inspection raw payload while keeping raw data', () => {
+        const normalized = normalizeInspectionResponse('sc-domain:a.example', 'https://a.example/page', rawInspection as any);
+
+        expect(normalized).toMatchObject({
+            inspectionUrl: 'https://a.example/page',
+            siteUrl: 'sc-domain:a.example',
+            verdict: 'PASS',
+            coverageState: 'Submitted and indexed',
+            indexingState: 'INDEXING_ALLOWED',
+            lastCrawlTime: '2026-05-25T10:00:00Z',
+            pageFetchState: 'SUCCESSFUL',
+            robotsTxtState: 'ALLOWED',
+            googleCanonical: 'https://a.example/page',
+            userCanonical: 'https://a.example/page',
+            referringUrls: ['https://a.example/'],
+            sitemap: ['https://a.example/sitemap.xml'],
+            inspectionResultLink: 'https://search.google.com/search-console/inspect',
+            raw: rawInspection
+        });
+    });
+
+    it('uses a fresh cache hit without calling Google again', async () => {
+        const first = await inspectUrlNormalized('sc-domain:a.example', 'https://a.example/page', 'en-US', tenant);
+        expect(first.metadata).toMatchObject({ cacheHit: false, apiCallMade: true, quotaUnitEstimate: 1 });
+
+        const second = await inspectUrlNormalized('sc-domain:a.example', 'https://a.example/page', 'en-US', tenant);
+        expect(second.metadata).toMatchObject({ cacheHit: true, apiCallMade: false, quotaUnitEstimate: 0 });
+        expect(inspectMock).toHaveBeenCalledTimes(1);
+
+        const cached = readFreshInspectionCache('tenant-a', 'sc-domain:a.example', 'https://a.example/page');
+        expect(cached?.entry.normalized?.coverageState).toBe('Submitted and indexed');
+    });
+
+    it('returns partial batch statuses for API errors and quota limits', async () => {
+        inspectMock
+            .mockResolvedValueOnce({ data: rawInspection })
+            .mockRejectedValueOnce(new Error('Google quota exhausted'));
+
+        const result = await inspectBatchWithCache('sc-domain:a.example', [
+            'https://a.example/one',
+            'https://a.example/two',
+            'https://a.example/three'
+        ], tenant, {
+            forceRefresh: true,
+            maxApiCallsPerRun: 2
+        });
+
+        expect(result.summary).toMatchObject({
+            requested: 3,
+            apiCallsMade: 2,
+            errors: 1,
+            quotaLimited: 1,
+            quotaUnitEstimate: 2
+        });
+        expect(result.results.map((row: any) => row.status)).toEqual(['ok', 'error', 'quota_limited']);
+    });
+
+    it('reports cache stats for Paperclip consumers', async () => {
+        await inspectUrlNormalized('sc-domain:a.example', 'https://a.example/page', 'en-US', tenant);
+        await inspectUrlNormalized('sc-domain:a.example', 'https://a.example/page', 'en-US', tenant);
+
+        const stats = getInspectionCacheStats(tenant, { siteUrl: 'sc-domain:a.example' });
+        expect(stats).toMatchObject({
+            tenantId: 'tenant-a',
+            siteUrl: 'sc-domain:a.example',
+            totalRequests: 2,
+            cacheHits: 1,
+            apiCalls: 1,
+            errors: 0,
+            quotaUnitEstimate: 1
+        });
+    });
+});

--- a/tests/inspection-jobs.test.ts
+++ b/tests/inspection-jobs.test.ts
@@ -152,6 +152,11 @@ describe('URL Inspection async jobs', () => {
             total: 105,
             hasMore: true
         });
+
+        const metadata = JSON.parse(readFileSync(findJobResultsFile(started.jobId), 'utf8'));
+        expect(metadata.results).toEqual([]);
+        const resultLines = readFileSync(findJobResultItemsFile(started.jobId), 'utf8').trim().split('\n');
+        expect(resultLines).toHaveLength(105);
     });
 
     it('cancels queued jobs before provider calls start', async () => {
@@ -211,6 +216,20 @@ function findJobFile(jobId: string) {
     const files = readdirSync(join(tempInspectionDir(), 'jobs'));
     const jobFile = files.find(file => file === `${jobId}.json`);
     if (!jobFile) throw new Error(`Job file not found for ${jobId}`);
+    return join(tempInspectionDir(), 'jobs', jobFile);
+}
+
+function findJobResultsFile(jobId: string) {
+    const files = readdirSync(join(tempInspectionDir(), 'jobs'));
+    const jobFile = files.find(file => file === `${jobId}.results.json`);
+    if (!jobFile) throw new Error(`Job results file not found for ${jobId}`);
+    return join(tempInspectionDir(), 'jobs', jobFile);
+}
+
+function findJobResultItemsFile(jobId: string) {
+    const files = readdirSync(join(tempInspectionDir(), 'jobs'));
+    const jobFile = files.find(file => file === `${jobId}.results.jsonl`);
+    if (!jobFile) throw new Error(`Job result items file not found for ${jobId}`);
     return join(tempInspectionDir(), 'jobs', jobFile);
 }
 

--- a/tests/inspection-jobs.test.ts
+++ b/tests/inspection-jobs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { TenantContext } from '../src/tenant/types.js';
@@ -126,9 +126,32 @@ describe('URL Inspection async jobs', () => {
         await waitForJob(started.jobId, 'completed');
 
         const page = getInspectionBatchJobResults(tenant, started.jobId, { offset: 1, limit: 1 });
-        expect(page.pagination).toMatchObject({ offset: 1, limit: 1, returned: 1, total: 2 });
+        expect(page.pagination).toMatchObject({ offset: 1, limit: 1, returned: 1, total: 2, hasMore: false });
         expect(page.results).toHaveLength(1);
+        const capped = getInspectionBatchJobResults(tenant, started.jobId, { limit: 5000 });
+        expect(capped.pagination.limit).toBe(1000);
         expect(() => getInspectionBatchJobStatus(otherTenant, started.jobId)).toThrow('job is not allowed');
+    });
+
+    it('uses a bounded default results page for large jobs', async () => {
+        const urls = Array.from({ length: 105 }, (_, index) => `not-a-url-${index}`);
+        const started = startInspectionBatchJob({
+            siteUrl: 'sc-domain:a.example',
+            urls,
+            tenant,
+            cacheMode: 'read_only',
+            maxApiCallsPerRun: 0
+        });
+        await waitForJob(started.jobId, 'completed');
+
+        const firstPage = getInspectionBatchJobResults(tenant, started.jobId);
+        expect(firstPage.pagination).toMatchObject({
+            offset: 0,
+            limit: 100,
+            returned: 100,
+            total: 105,
+            hasMore: true
+        });
     });
 
     it('cancels queued jobs before provider calls start', async () => {
@@ -147,6 +170,32 @@ describe('URL Inspection async jobs', () => {
         expect(status.status).toBe('cancelled');
         expect(inspectMock).not.toHaveBeenCalled();
     });
+
+    it('cleans up expired terminal jobs before new jobs are started', async () => {
+        const started = startInspectionBatchJob({
+            siteUrl: 'sc-domain:a.example',
+            urls: ['not-a-url'],
+            tenant,
+            cacheMode: 'read_only',
+            maxApiCallsPerRun: 0
+        });
+        await waitForJob(started.jobId, 'completed');
+
+        const jobFile = findJobFile(started.jobId);
+        const job = JSON.parse(readFileSync(jobFile, 'utf8'));
+        job.expiresAt = '2000-01-01T00:00:00.000Z';
+        writeFileSync(jobFile, `${JSON.stringify(job, null, 2)}\n`);
+
+        startInspectionBatchJob({
+            siteUrl: 'sc-domain:a.example',
+            urls: [],
+            tenant,
+            cacheMode: 'read_only',
+            maxApiCallsPerRun: 0
+        });
+
+        expect(() => getInspectionBatchJobStatus(tenant, started.jobId)).toThrow('not found');
+    });
 });
 
 async function waitForJob(jobId: string, expectedStatus: string) {
@@ -156,4 +205,17 @@ async function waitForJob(jobId: string, expectedStatus: string) {
         await new Promise(resolve => setTimeout(resolve, 10));
     }
     throw new Error(`Job ${jobId} did not reach ${expectedStatus}`);
+}
+
+function findJobFile(jobId: string) {
+    const files = readdirSync(join(tempInspectionDir(), 'jobs'));
+    const jobFile = files.find(file => file === `${jobId}.json`);
+    if (!jobFile) throw new Error(`Job file not found for ${jobId}`);
+    return join(tempInspectionDir(), 'jobs', jobFile);
+}
+
+function tempInspectionDir() {
+    const dir = process.env.MCP_INSPECTION_CACHE_DIR;
+    if (!dir) throw new Error('MCP_INSPECTION_CACHE_DIR is not set');
+    return dir;
 }

--- a/tests/inspection-jobs.test.ts
+++ b/tests/inspection-jobs.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { TenantContext } from '../src/tenant/types.js';
+import { getSearchConsoleClient } from '../src/google/client.js';
+import {
+    cancelInspectionBatchJob,
+    getInspectionBatchJobResults,
+    getInspectionBatchJobStatus,
+    startInspectionBatchJob
+} from '../src/google/tools/inspection-jobs.js';
+
+vi.mock('../src/google/client.js', () => ({
+    getSearchConsoleClient: vi.fn()
+}));
+
+const tenant: TenantContext = {
+    tenantId: 'tenant-a',
+    displayName: 'Tenant A',
+    admin: false,
+    allowedTools: ['inspection_*'],
+    deniedTools: [],
+    allowMutations: false,
+    allowedMutatingTools: [],
+    engines: {
+        google: {
+            accountIds: ['google_a'],
+            allowedSites: ['sc-domain:a.example']
+        }
+    },
+    limits: {
+        maxRows: 100,
+        maxBatchUrls: 2,
+        requestTimeoutSeconds: 30
+    },
+    indexNowKeys: {}
+};
+
+const otherTenant = {
+    ...tenant,
+    tenantId: 'tenant-b'
+};
+
+const rawInspection = {
+    inspectionResult: {
+        inspectionResultLink: 'https://search.google.com/search-console/inspect',
+        indexStatusResult: {
+            verdict: 'PASS',
+            coverageState: 'Submitted and indexed',
+            indexingState: 'INDEXING_ALLOWED',
+            pageFetchState: 'SUCCESSFUL',
+            robotsTxtState: 'ALLOWED'
+        }
+    }
+};
+
+describe('URL Inspection async jobs', () => {
+    let tempDir: string;
+    let inspectMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        tempDir = mkdtempSync(join(tmpdir(), 'inspection-jobs-'));
+        process.env.MCP_INSPECTION_CACHE_DIR = tempDir;
+        process.env.MCP_INSPECTION_JOB_CHUNK_SIZE = '1';
+        inspectMock = vi.fn().mockResolvedValue({ data: rawInspection });
+        vi.mocked(getSearchConsoleClient).mockResolvedValue({
+            urlInspection: {
+                index: {
+                    inspect: inspectMock
+                }
+            }
+        } as any);
+    });
+
+    afterEach(() => {
+        delete process.env.MCP_INSPECTION_CACHE_DIR;
+        delete process.env.MCP_INSPECTION_JOB_CHUNK_SIZE;
+        rmSync(tempDir, { recursive: true, force: true });
+        vi.clearAllMocks();
+    });
+
+    it('starts and completes an async batch job with partial per-URL statuses', async () => {
+        const started = startInspectionBatchJob({
+            siteUrl: 'sc-domain:a.example',
+            urls: [
+                'not-a-url',
+                'https://b.example/blocked',
+                'https://a.example/one',
+                'https://a.example/two'
+            ],
+            tenant,
+            cacheMode: 'bypass',
+            maxApiCallsPerRun: 1
+        });
+
+        const status = await waitForJob(started.jobId, 'completed');
+        expect(status.summary).toMatchObject({
+            requested: 4,
+            returned: 4,
+            invalidUrls: 1,
+            forbiddenUrls: 1,
+            apiCallsMade: 1,
+            quotaLimited: 1,
+            quotaUnitEstimate: 1
+        });
+
+        const results = getInspectionBatchJobResults(tenant, started.jobId);
+        expect(results.results.map((row: any) => row.status)).toEqual([
+            'invalid_url',
+            'forbidden_url',
+            'ok',
+            'quota_limited'
+        ]);
+        expect(inspectMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns paginated results and enforces tenant ownership', async () => {
+        const started = startInspectionBatchJob({
+            siteUrl: 'sc-domain:a.example',
+            urls: ['https://a.example/one', 'https://a.example/two'],
+            tenant,
+            cacheMode: 'bypass',
+            maxApiCallsPerRun: 2
+        });
+        await waitForJob(started.jobId, 'completed');
+
+        const page = getInspectionBatchJobResults(tenant, started.jobId, { offset: 1, limit: 1 });
+        expect(page.pagination).toMatchObject({ offset: 1, limit: 1, returned: 1, total: 2 });
+        expect(page.results).toHaveLength(1);
+        expect(() => getInspectionBatchJobStatus(otherTenant, started.jobId)).toThrow('job is not allowed');
+    });
+
+    it('cancels queued jobs before provider calls start', async () => {
+        const started = startInspectionBatchJob({
+            siteUrl: 'sc-domain:a.example',
+            urls: ['https://a.example/one'],
+            tenant,
+            cacheMode: 'bypass',
+            maxApiCallsPerRun: 1
+        });
+
+        const cancelled = cancelInspectionBatchJob(tenant, started.jobId);
+        expect(cancelled).toMatchObject({ cancelAccepted: true, status: 'cancelled' });
+        await new Promise(resolve => setTimeout(resolve, 20));
+        const status = getInspectionBatchJobStatus(tenant, started.jobId);
+        expect(status.status).toBe('cancelled');
+        expect(inspectMock).not.toHaveBeenCalled();
+    });
+});
+
+async function waitForJob(jobId: string, expectedStatus: string) {
+    for (let attempt = 0; attempt < 50; attempt++) {
+        const status = getInspectionBatchJobStatus(tenant, jobId);
+        if (status.status === expectedStatus) return status;
+        await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    throw new Error(`Job ${jobId} did not reach ${expectedStatus}`);
+}

--- a/tests/schema-validator-extended.test.ts
+++ b/tests/schema-validator-extended.test.ts
@@ -116,7 +116,9 @@ describe('Schema Validator Extended', () => {
         const result = await validateSchema('https://example.com', 'url');
         expect(result.valid).toBe(true);
         expect(result.schemas).toHaveLength(1);
-        expect(mockFetch).toHaveBeenCalledWith('https://example.com');
+        expect(mockFetch).toHaveBeenCalledWith('https://example.com/', expect.objectContaining({
+            redirect: 'follow'
+        }));
     });
 
     it('should handle URL fetch error', async () => {

--- a/tests/schema-validator-security.test.ts
+++ b/tests/schema-validator-security.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { validateSchema } from '../src/common/tools/schema-validator.js';
+
+describe('Schema validator URL safety', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('blocks localhost and private network URL fetches', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+        const localhost = await validateSchema('http://127.0.0.1:8080/schema', 'url');
+        const metadata = await validateSchema('http://169.254.169.254/latest/meta-data', 'url');
+
+        expect(localhost.valid).toBe(false);
+        expect(localhost.errors[0]).toContain('URL host is not allowed');
+        expect(metadata.valid).toBe(false);
+        expect(metadata.errors[0]).toContain('URL host is not allowed');
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-http schemes before fetching', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+        const result = await validateSchema('file:///etc/passwd', 'url');
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain('Only http and https URLs are allowed');
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects oversized responses', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('too large', {
+            status: 200,
+            headers: {
+                'content-length': '1000001'
+            }
+        }));
+
+        const result = await validateSchema('https://example.com/schema', 'url');
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain('Response is too large');
+    });
+});

--- a/tests/security-redaction.test.ts
+++ b/tests/security-redaction.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { formatError } from '../src/common/errors.js';
+import { sanitizeForLog } from '../src/utils/redaction.js';
+
+describe('Secret redaction', () => {
+    it('redacts bearer tokens, API keys, hashes, and private keys', () => {
+        const raw = [
+            'Authorization: Bearer scmcp_super_secret',
+            'https://example.com/path?apikey=bing-secret&x=1',
+            'token: "plain-token"',
+            'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----'
+        ].join(' ');
+
+        const sanitized = sanitizeForLog(raw);
+
+        expect(sanitized).not.toContain('scmcp_super_secret');
+        expect(sanitized).not.toContain('bing-secret');
+        expect(sanitized).not.toContain('plain-token');
+        expect(sanitized).not.toContain('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+        expect(sanitized).not.toContain('abc');
+        expect(sanitized).toContain('[REDACTED]');
+    });
+
+    it('formats MCP errors without leaking raw secret material', () => {
+        const response = formatError(new Error('Fetch failed: apikey=abc123 Authorization: Bearer secret-token'));
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).not.toContain('abc123');
+        expect(response.content[0].text).not.toContain('secret-token');
+    });
+});

--- a/tests/tenant-guard.test.ts
+++ b/tests/tenant-guard.test.ts
@@ -84,6 +84,10 @@ describe('Tenant guard', () => {
             'https://www.a.example/two',
             'https://www.a.example/three'
         ])).toThrow('batch URL limit exceeded');
+        expect(() => guardToolArguments(tenant, 'inspection_batch_inspect', {
+            siteUrl: 'sc-domain:a.example',
+            urls: ['https://www.a.example/one', 'https://b.example/two']
+        })).toThrow('URL is not allowed');
     });
 
     it('filters sites_list to tenant-authorized sites only', async () => {

--- a/tests/tenant-guard.test.ts
+++ b/tests/tenant-guard.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TenantContext } from '../src/tenant/types.js';
+import {
+    assertBatchUrlsAllowed,
+    assertGa4PropertyAllowed,
+    assertGoogleSiteAllowed,
+    assertSitemapBelongsToAllowedSite,
+    assertToolAllowed,
+    assertUrlBelongsToAllowedSite,
+    guardToolArguments,
+    resolveTenantAccount,
+    tenantSitesList
+} from '../src/tenant/guard.js';
+import { loadConfig } from '../src/common/auth/config.js';
+
+vi.mock('../src/common/auth/config.js', async (importOriginal) => {
+    const actual: any = await importOriginal();
+    return {
+        ...actual,
+        loadConfig: vi.fn()
+    };
+});
+
+const tenant: TenantContext = {
+    tenantId: 'tenant-a',
+    displayName: 'Tenant A',
+    admin: false,
+    allowedTools: ['analytics_*', 'inspection_*', 'sites_list', 'schema_validate', 'pagespeed_*', 'bing_index_now'],
+    deniedTools: ['sites_delete'],
+    allowMutations: false,
+    allowedMutatingTools: [],
+    engines: {
+        google: {
+            accountIds: ['google_a'],
+            allowedSites: ['sc-domain:a.example'],
+            defaultSite: 'sc-domain:a.example'
+        },
+        bing: {
+            accountIds: ['bing_a'],
+            allowedSites: ['https://www.a.example/']
+        },
+        ga4: {
+            accountIds: ['ga4_a'],
+            allowedProperties: ['12345']
+        }
+    },
+    limits: {
+        maxRows: 100,
+        maxBatchUrls: 2,
+        requestTimeoutSeconds: 30
+    },
+    indexNowKeys: {
+        'www.a.example': { key: 'server-side-key' }
+    }
+};
+
+describe('Tenant guard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('allows wildcard tools and rejects denied or unlisted tools', () => {
+        expect(() => assertToolAllowed(tenant, 'analytics_query')).not.toThrow();
+        expect(() => assertToolAllowed(tenant, 'sites_delete')).toThrow('denied');
+        expect(() => assertToolAllowed(tenant, 'accounts_list')).toThrow('admin tenant');
+        expect(() => assertToolAllowed(tenant, 'sitemaps_submit')).toThrow('mutating tool');
+        expect(() => assertToolAllowed(tenant, 'ga4_realtime')).toThrow('not allowed');
+    });
+
+    it('enforces exact sc-domain matching with subdomain URL allowance', () => {
+        expect(() => assertGoogleSiteAllowed(tenant, 'sc-domain:a.example')).not.toThrow();
+        expect(() => assertUrlBelongsToAllowedSite(tenant, 'https://blog.a.example/post')).not.toThrow();
+        expect(() => assertGoogleSiteAllowed(tenant, 'sc-domain:b.example')).toThrow('site is not allowed');
+        expect(() => assertUrlBelongsToAllowedSite(tenant, 'https://b.example/post')).toThrow('URL is not allowed');
+    });
+
+    it('enforces GA4 properties, sitemap URLs, and batch limits', () => {
+        expect(() => assertGa4PropertyAllowed(tenant, '12345')).not.toThrow();
+        expect(() => assertGa4PropertyAllowed(tenant, '99999')).toThrow('GA4 property is not allowed');
+        expect(() => assertSitemapBelongsToAllowedSite(tenant, 'https://www.a.example/sitemap.xml')).not.toThrow();
+        expect(() => assertSitemapBelongsToAllowedSite(tenant, 'https://b.example/sitemap.xml')).toThrow('URL is not allowed');
+        expect(() => assertBatchUrlsAllowed(tenant, [
+            'https://www.a.example/one',
+            'https://www.a.example/two',
+            'https://www.a.example/three'
+        ])).toThrow('batch URL limit exceeded');
+    });
+
+    it('filters sites_list to tenant-authorized sites only', async () => {
+        await expect(tenantSitesList(tenant, 'google')).resolves.toEqual([
+            { tenant: 'tenant-a', engine: 'google', sites: ['sc-domain:a.example'] }
+        ]);
+    });
+
+    it('resolves accounts only from tenant account IDs', async () => {
+        vi.mocked(loadConfig).mockResolvedValue({
+            accounts: {
+                google_a: {
+                    id: 'google_a',
+                    engine: 'google',
+                    alias: 'tenant-a',
+                    websites: ['sc-domain:a.example']
+                },
+                google_b: {
+                    id: 'google_b',
+                    engine: 'google',
+                    alias: 'tenant-b',
+                    websites: ['sc-domain:b.example']
+                }
+            }
+        });
+
+        await expect(resolveTenantAccount(tenant, 'sc-domain:a.example', 'google')).resolves.toMatchObject({
+            id: 'google_a'
+        });
+        await expect(resolveTenantAccount(tenant, 'sc-domain:b.example', 'google')).rejects.toThrow('site is not allowed');
+    });
+
+    it('guards tenant URLs before schema and IndexNow tool execution', () => {
+        const mutationTenant = {
+            ...tenant,
+            allowMutations: true,
+            allowedMutatingTools: ['bing_index_now']
+        };
+
+        expect(() => guardToolArguments(tenant, 'schema_validate', {
+            type: 'url',
+            data: 'https://www.a.example/page'
+        })).not.toThrow();
+        expect(() => guardToolArguments(tenant, 'schema_validate', {
+            type: 'url',
+            data: 'https://b.example/page'
+        })).toThrow('URL is not allowed');
+        expect(() => guardToolArguments(mutationTenant, 'bing_index_now', {
+            host: 'www.a.example',
+            key: 'client-supplied-key',
+            urlList: ['https://www.a.example/post']
+        })).toThrow('IndexNow key must be configured server-side');
+        expect(() => guardToolArguments(mutationTenant, 'bing_index_now', {
+            host: 'www.a.example',
+            urlList: ['https://other.a.example/post']
+        })).toThrow('IndexNow URL host does not match');
+    });
+});

--- a/tests/tenant-guard.test.ts
+++ b/tests/tenant-guard.test.ts
@@ -84,10 +84,14 @@ describe('Tenant guard', () => {
             'https://www.a.example/two',
             'https://www.a.example/three'
         ])).toThrow('batch URL limit exceeded');
-        expect(() => guardToolArguments(tenant, 'inspection_batch_inspect', {
+        expect(() => guardToolArguments(tenant, 'inspection_batch', {
             siteUrl: 'sc-domain:a.example',
             urls: ['https://www.a.example/one', 'https://b.example/two']
         })).toThrow('URL is not allowed');
+        expect(() => guardToolArguments(tenant, 'inspection_batch_inspect', {
+            siteUrl: 'sc-domain:a.example',
+            urls: ['https://www.a.example/one', 'https://b.example/two']
+        })).not.toThrow();
     });
 
     it('filters sites_list to tenant-authorized sites only', async () => {

--- a/tests/tenant-http.integration.test.ts
+++ b/tests/tenant-http.integration.test.ts
@@ -26,7 +26,7 @@ describe('Tenant HTTP integration', () => {
         tempDir = undefined;
     });
 
-    async function startTenantServer(options: { useFactory?: boolean; sessionTtlMs?: string } = {}) {
+    async function startTenantServer(options: { useFactory?: boolean; sessionTtlMs?: string; cleanupIntervalMs?: string; maxSessions?: string } = {}) {
         tempDir = mkdtempSync(join(tmpdir(), 'scmcp-http-'));
         const tenantsDir = join(tempDir, 'tenants');
         const tokensDir = join(tempDir, 'tokens');
@@ -62,6 +62,8 @@ describe('Tenant HTTP integration', () => {
         process.env.MCP_BIND_HOST = '127.0.0.1';
         process.env.MCP_PORT = '0';
         if (options.sessionTtlMs) process.env.MCP_HTTP_SESSION_TTL_MS = options.sessionTtlMs;
+        if (options.cleanupIntervalMs) process.env.MCP_HTTP_SESSION_CLEANUP_INTERVAL_MS = options.cleanupIntervalMs;
+        if (options.maxSessions) process.env.MCP_HTTP_MAX_SESSIONS = options.maxSessions;
 
         const createServer = () => {
             const server = new McpServer({ name: 'tenant-http-test', version: '1.0.0' });
@@ -125,6 +127,17 @@ describe('Tenant HTTP integration', () => {
         });
     }
 
+    async function deleteSession(url: URL, token: string, sessionId: string) {
+        return fetch(url, {
+            method: 'DELETE',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                accept: 'application/json, text/event-stream',
+                'mcp-session-id': sessionId
+            }
+        });
+    }
+
     it('requires a valid bearer token before MCP initialization', async () => {
         const { token, url } = await startTenantServer();
 
@@ -167,7 +180,7 @@ describe('Tenant HTTP integration', () => {
     });
 
     it('expires inactive streamable HTTP sessions after the configured TTL', async () => {
-        const { token, url } = await startTenantServer({ useFactory: true, sessionTtlMs: '1' });
+        const { token, url } = await startTenantServer({ useFactory: true, sessionTtlMs: '5', cleanupIntervalMs: '5' });
 
         const initialized = await initialize(url, token, 1);
         expect(initialized.status).toBe(200);
@@ -175,11 +188,44 @@ describe('Tenant HTTP integration', () => {
         expect(sessionId).toBeTruthy();
         await initialized.json();
 
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await new Promise(resolve => setTimeout(resolve, 30));
 
         const expired = await toolsList(url, token, sessionId!, 2);
         expect(expired.status).toBe(400);
         await expect(expired.json()).resolves.toMatchObject({
+            error: { message: 'Bad Request: No valid session ID provided' }
+        });
+    });
+
+    it('rejects new initialize requests when the session cap is reached', async () => {
+        const { token, url } = await startTenantServer({ useFactory: true, maxSessions: '1' });
+
+        const first = await initialize(url, token, 1);
+        expect(first.status).toBe(200);
+        await first.json();
+
+        const second = await initialize(url, token, 2);
+        expect(second.status).toBe(503);
+        await expect(second.json()).resolves.toMatchObject({
+            error: { message: 'Service Unavailable: too many active MCP sessions' }
+        });
+    });
+
+    it('removes a streamable HTTP session after DELETE', async () => {
+        const { token, url } = await startTenantServer({ useFactory: true });
+
+        const initialized = await initialize(url, token, 1);
+        expect(initialized.status).toBe(200);
+        const sessionId = initialized.headers.get('mcp-session-id');
+        expect(sessionId).toBeTruthy();
+        await initialized.json();
+
+        const deleted = await deleteSession(url, token, sessionId!);
+        expect([200, 202, 204]).toContain(deleted.status);
+
+        const afterDelete = await toolsList(url, token, sessionId!, 2);
+        expect(afterDelete.status).toBe(400);
+        await expect(afterDelete.json()).resolves.toMatchObject({
             error: { message: 'Bad Request: No valid session ID provided' }
         });
     });

--- a/tests/tenant-http.integration.test.ts
+++ b/tests/tenant-http.integration.test.ts
@@ -26,7 +26,7 @@ describe('Tenant HTTP integration', () => {
         tempDir = undefined;
     });
 
-    async function startTenantServer(options: { useFactory?: boolean } = {}) {
+    async function startTenantServer(options: { useFactory?: boolean; sessionTtlMs?: string } = {}) {
         tempDir = mkdtempSync(join(tmpdir(), 'scmcp-http-'));
         const tenantsDir = join(tempDir, 'tenants');
         const tokensDir = join(tempDir, 'tokens');
@@ -61,6 +61,7 @@ describe('Tenant HTTP integration', () => {
         process.env.MCP_TOKEN_REGISTRY = tokensPath;
         process.env.MCP_BIND_HOST = '127.0.0.1';
         process.env.MCP_PORT = '0';
+        if (options.sessionTtlMs) process.env.MCP_HTTP_SESSION_TTL_MS = options.sessionTtlMs;
 
         const createServer = () => {
             const server = new McpServer({ name: 'tenant-http-test', version: '1.0.0' });
@@ -106,6 +107,24 @@ describe('Tenant HTTP integration', () => {
         });
     }
 
+    async function toolsList(url: URL, token: string, sessionId: string, id: number) {
+        return fetch(url, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'content-type': 'application/json',
+                accept: 'application/json, text/event-stream',
+                'mcp-session-id': sessionId
+            },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id,
+                method: 'tools/list',
+                params: {}
+            })
+        });
+    }
+
     it('requires a valid bearer token before MCP initialization', async () => {
         const { token, url } = await startTenantServer();
 
@@ -144,6 +163,24 @@ describe('Tenant HTTP integration', () => {
         expect(second.headers.get('mcp-session-id')).toBeTruthy();
         await expect(second.json()).resolves.toMatchObject({
             result: { serverInfo: { name: 'tenant-http-test' } }
+        });
+    });
+
+    it('expires inactive streamable HTTP sessions after the configured TTL', async () => {
+        const { token, url } = await startTenantServer({ useFactory: true, sessionTtlMs: '1' });
+
+        const initialized = await initialize(url, token, 1);
+        expect(initialized.status).toBe(200);
+        const sessionId = initialized.headers.get('mcp-session-id');
+        expect(sessionId).toBeTruthy();
+        await initialized.json();
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        const expired = await toolsList(url, token, sessionId!, 2);
+        expect(expired.status).toBe(400);
+        await expect(expired.json()).resolves.toMatchObject({
+            error: { message: 'Bad Request: No valid session ID provided' }
         });
     });
 });

--- a/tests/tenant-http.integration.test.ts
+++ b/tests/tenant-http.integration.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { installTenantGuard } from '../src/tenant/tool-guard.js';
+import { startHttpServer } from '../src/tenant/http.js';
+import { createTokenRecord, resetTenantRegistryCache } from '../src/tenant/registry.js';
+
+describe('Tenant HTTP integration', () => {
+    const originalEnv = { ...process.env };
+    let tempDir: string | undefined;
+    let httpServer: Server | undefined;
+
+    afterEach(async () => {
+        process.env = { ...originalEnv };
+        resetTenantRegistryCache();
+        if (httpServer) {
+            await new Promise<void>((resolve) => httpServer!.close(() => resolve()));
+            httpServer = undefined;
+        }
+        if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+        tempDir = undefined;
+    });
+
+    async function startTenantServer() {
+        tempDir = mkdtempSync(join(tmpdir(), 'scmcp-http-'));
+        const tenantsDir = join(tempDir, 'tenants');
+        const tokensDir = join(tempDir, 'tokens');
+        const tokensPath = join(tokensDir, 'tokens.json');
+        mkdirSync(tenantsDir, { recursive: true });
+        mkdirSync(tokensDir, { recursive: true });
+
+        const token = createTokenRecord('tenant-a', 'integration', 'tenant-a-primary');
+        writeFileSync(tokensPath, JSON.stringify({ tokens: [token.record] }));
+        writeFileSync(join(tenantsDir, 'tenant-a.json'), JSON.stringify({
+            tenant_id: 'tenant-a',
+            display_name: 'Tenant A',
+            enabled: true,
+            engines: {
+                google: {
+                    account_ids: ['google_a'],
+                    allowed_sites: ['sc-domain:a.example']
+                }
+            },
+            allowed_tools: ['echo_site', 'sites_list'],
+            denied_tools: [],
+            limits: {
+                max_rows: 100,
+                max_batch_urls: 5,
+                request_timeout_seconds: 30
+            }
+        }));
+
+        process.env.MCP_REQUIRE_TENANT_TOKEN = 'true';
+        process.env.MCP_PRODUCTION_MODE = 'true';
+        process.env.MCP_TENANTS_DIR = tenantsDir;
+        process.env.MCP_TOKEN_REGISTRY = tokensPath;
+        process.env.MCP_BIND_HOST = '127.0.0.1';
+        process.env.MCP_PORT = '0';
+
+        const server = new McpServer({ name: 'tenant-http-test', version: '1.0.0' });
+        installTenantGuard(server);
+        server.tool(
+            'echo_site',
+            'Echoes a tenant-authorized site',
+            { siteUrl: z.string() },
+            async ({ siteUrl }) => ({ content: [{ type: 'text', text: siteUrl }] })
+        );
+        server.tool(
+            'sites_list',
+            'Tenant-filtered sites list',
+            { engine: z.enum(['google', 'bing', 'ga4']).optional() },
+            async () => ({ content: [{ type: 'text', text: 'should be replaced by tenant guard' }] })
+        );
+
+        httpServer = await startHttpServer(server) as Server;
+        const port = (httpServer.address() as AddressInfo).port;
+        return { token: token.plaintext, url: new URL(`http://127.0.0.1:${port}/mcp`) };
+    }
+
+    it('requires a valid bearer token before MCP initialization', async () => {
+        const { token, url } = await startTenantServer();
+
+        const missing = await fetch(url, { method: 'POST' });
+        expect(missing.status).toBe(401);
+        await expect(missing.json()).resolves.toMatchObject({
+            error: { message: 'Missing Authorization bearer token' }
+        });
+
+        const invalid = await fetch(url, {
+            method: 'POST',
+            headers: { Authorization: 'Bearer invalid-token' }
+        });
+        expect(invalid.status).toBe(401);
+        await expect(invalid.json()).resolves.toMatchObject({
+            error: { message: 'Invalid or disabled bearer token' }
+        });
+
+        const initialized = await fetch(url, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'content-type': 'application/json',
+                accept: 'application/json, text/event-stream'
+            },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'initialize',
+                params: {
+                    protocolVersion: '2025-06-18',
+                    capabilities: {},
+                    clientInfo: { name: 'test-client', version: '1.0.0' }
+                }
+            })
+        });
+        expect(initialized.status).toBe(200);
+        await expect(initialized.json()).resolves.toMatchObject({
+            result: { serverInfo: { name: 'tenant-http-test' } }
+        });
+    });
+});

--- a/tests/tenant-http.integration.test.ts
+++ b/tests/tenant-http.integration.test.ts
@@ -26,7 +26,7 @@ describe('Tenant HTTP integration', () => {
         tempDir = undefined;
     });
 
-    async function startTenantServer() {
+    async function startTenantServer(options: { useFactory?: boolean } = {}) {
         tempDir = mkdtempSync(join(tmpdir(), 'scmcp-http-'));
         const tenantsDir = join(tempDir, 'tenants');
         const tokensDir = join(tempDir, 'tokens');
@@ -62,24 +62,48 @@ describe('Tenant HTTP integration', () => {
         process.env.MCP_BIND_HOST = '127.0.0.1';
         process.env.MCP_PORT = '0';
 
-        const server = new McpServer({ name: 'tenant-http-test', version: '1.0.0' });
-        installTenantGuard(server);
-        server.tool(
-            'echo_site',
-            'Echoes a tenant-authorized site',
-            { siteUrl: z.string() },
-            async ({ siteUrl }) => ({ content: [{ type: 'text', text: siteUrl }] })
-        );
-        server.tool(
-            'sites_list',
-            'Tenant-filtered sites list',
-            { engine: z.enum(['google', 'bing', 'ga4']).optional() },
-            async () => ({ content: [{ type: 'text', text: 'should be replaced by tenant guard' }] })
-        );
+        const createServer = () => {
+            const server = new McpServer({ name: 'tenant-http-test', version: '1.0.0' });
+            installTenantGuard(server);
+            server.tool(
+                'echo_site',
+                'Echoes a tenant-authorized site',
+                { siteUrl: z.string() },
+                async ({ siteUrl }) => ({ content: [{ type: 'text', text: siteUrl }] })
+            );
+            server.tool(
+                'sites_list',
+                'Tenant-filtered sites list',
+                { engine: z.enum(['google', 'bing', 'ga4']).optional() },
+                async () => ({ content: [{ type: 'text', text: 'should be replaced by tenant guard' }] })
+            );
+            return server;
+        };
 
-        httpServer = await startHttpServer(server) as Server;
+        httpServer = await startHttpServer(options.useFactory ? createServer : createServer()) as Server;
         const port = (httpServer.address() as AddressInfo).port;
         return { token: token.plaintext, url: new URL(`http://127.0.0.1:${port}/mcp`) };
+    }
+
+    async function initialize(url: URL, token: string, id: number) {
+        return fetch(url, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'content-type': 'application/json',
+                accept: 'application/json, text/event-stream'
+            },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id,
+                method: 'initialize',
+                params: {
+                    protocolVersion: '2025-06-18',
+                    capabilities: {},
+                    clientInfo: { name: `test-client-${id}`, version: '1.0.0' }
+                }
+            })
+        });
     }
 
     it('requires a valid bearer token before MCP initialization', async () => {
@@ -100,26 +124,25 @@ describe('Tenant HTTP integration', () => {
             error: { message: 'Invalid or disabled bearer token' }
         });
 
-        const initialized = await fetch(url, {
-            method: 'POST',
-            headers: {
-                Authorization: `Bearer ${token}`,
-                'content-type': 'application/json',
-                accept: 'application/json, text/event-stream'
-            },
-            body: JSON.stringify({
-                jsonrpc: '2.0',
-                id: 1,
-                method: 'initialize',
-                params: {
-                    protocolVersion: '2025-06-18',
-                    capabilities: {},
-                    clientInfo: { name: 'test-client', version: '1.0.0' }
-                }
-            })
-        });
+        const initialized = await initialize(url, token, 1);
         expect(initialized.status).toBe(200);
         await expect(initialized.json()).resolves.toMatchObject({
+            result: { serverInfo: { name: 'tenant-http-test' } }
+        });
+    });
+
+    it('creates a fresh MCP server for each streamable HTTP session when a factory is provided', async () => {
+        const { token, url } = await startTenantServer({ useFactory: true });
+
+        const first = await initialize(url, token, 1);
+        expect(first.status).toBe(200);
+        expect(first.headers.get('mcp-session-id')).toBeTruthy();
+        await first.json();
+
+        const second = await initialize(url, token, 2);
+        expect(second.status).toBe(200);
+        expect(second.headers.get('mcp-session-id')).toBeTruthy();
+        await expect(second.json()).resolves.toMatchObject({
             result: { serverInfo: { name: 'tenant-http-test' } }
         });
     });

--- a/tests/tenant-registry.test.ts
+++ b/tests/tenant-registry.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+    appendTokenRecord,
+    createTokenRecord,
+    hashBearerToken,
+    resetTenantRegistryCache,
+    resolveBearerToken
+} from '../src/tenant/registry.js';
+
+describe('Tenant registry', () => {
+    const originalEnv = { ...process.env };
+    let tempDir: string | undefined;
+
+    afterEach(() => {
+        process.env = { ...originalEnv };
+        resetTenantRegistryCache();
+        if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+        tempDir = undefined;
+    });
+
+    function setupRegistry() {
+        tempDir = mkdtempSync(join(tmpdir(), 'scmcp-tenants-'));
+        const tenantsDir = join(tempDir, 'tenants');
+        const tokensPath = join(tempDir, 'tokens', 'tokens.json');
+        mkdirSync(tenantsDir, { recursive: true });
+        mkdirSync(join(tempDir, 'tokens'), { recursive: true });
+
+        process.env.MCP_TENANTS_DIR = tenantsDir;
+        process.env.MCP_TOKEN_REGISTRY = tokensPath;
+
+        writeFileSync(join(tenantsDir, 'tenant-a.json'), JSON.stringify({
+            tenant_id: 'tenant-a',
+            display_name: 'Tenant A',
+            enabled: true,
+            engines: {
+                google: {
+                    account_ids: ['google_a'],
+                    allowed_sites: ['sc-domain:a.example']
+                }
+            },
+            allowed_tools: ['analytics_*'],
+            limits: {
+                max_rows: 100,
+                max_batch_urls: 5,
+                request_timeout_seconds: 30
+            }
+        }));
+
+        return { tokensPath };
+    }
+
+    it('stores only token hashes and resolves enabled tokens to tenants', () => {
+        const { tokensPath } = setupRegistry();
+        const record = createTokenRecord('tenant-a', 'primary', 'tenant-a-primary');
+        writeFileSync(tokensPath, JSON.stringify({ tokens: [record.record] }));
+
+        const resolved = resolveBearerToken(record.plaintext);
+
+        expect(resolved.token.token_id).toBe('tenant-a-primary');
+        expect(resolved.tenant.tenantId).toBe('tenant-a');
+        expect(record.record.token_hash).toBe(hashBearerToken(record.plaintext));
+        expect(readFileSync(tokensPath, 'utf8')).not.toContain(record.plaintext);
+    });
+
+    it('rejects unknown and disabled tokens', () => {
+        const { tokensPath } = setupRegistry();
+        const record = createTokenRecord('tenant-a', 'disabled', 'tenant-a-disabled');
+        writeFileSync(tokensPath, JSON.stringify({
+            tokens: [{ ...record.record, enabled: false }]
+        }));
+
+        expect(() => resolveBearerToken('unknown')).toThrow('Invalid or disabled bearer token');
+        expect(() => resolveBearerToken(record.plaintext)).toThrow('Invalid or disabled bearer token');
+    });
+
+    it('appends token records without writing plaintext tokens', () => {
+        const { tokensPath } = setupRegistry();
+        const { plaintext, record } = createTokenRecord('tenant-a', 'created');
+
+        appendTokenRecord(record);
+
+        const saved = readFileSync(tokensPath, 'utf8');
+        expect(saved).toContain(record.token_hash);
+        expect(saved).not.toContain(plaintext);
+    });
+});

--- a/tests/tenant-resolver.test.ts
+++ b/tests/tenant-resolver.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadConfig } from '../src/common/auth/config.js';
+import { resolveAccount } from '../src/common/auth/resolver.js';
+import { runWithTenant } from '../src/tenant/context.js';
+import { TenantContext } from '../src/tenant/types.js';
+
+vi.mock('../src/common/auth/config.js', async (importOriginal) => {
+    const actual: any = await importOriginal();
+    return {
+        ...actual,
+        loadConfig: vi.fn()
+    };
+});
+
+const tenant: TenantContext = {
+    tenantId: 'tenant-a',
+    displayName: 'Tenant A',
+    admin: false,
+    allowedTools: ['*'],
+    deniedTools: [],
+    allowMutations: false,
+    allowedMutatingTools: [],
+    engines: {
+        google: {
+            accountIds: ['tenant_google'],
+            allowedSites: ['sc-domain:a.example']
+        }
+    },
+    limits: {
+        maxRows: 100,
+        maxBatchUrls: 10,
+        requestTimeoutSeconds: 30
+    },
+    indexNowKeys: {}
+};
+
+describe('Tenant-aware account resolver', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(loadConfig).mockResolvedValue({
+            accounts: {
+                tenant_google: {
+                    id: 'tenant_google',
+                    engine: 'google',
+                    alias: 'Tenant Google',
+                    websites: ['sc-domain:a.example']
+                },
+                global_google: {
+                    id: 'global_google',
+                    engine: 'google',
+                    alias: 'Global Google'
+                },
+                other_tenant_google: {
+                    id: 'other_tenant_google',
+                    engine: 'google',
+                    alias: 'Other Google',
+                    websites: ['sc-domain:b.example']
+                }
+            }
+        });
+    });
+
+    it('does not fall back to global accounts inside tenant context', async () => {
+        await expect(runWithTenant(tenant, () => resolveAccount('sc-domain:b.example', 'google')))
+            .rejects.toThrow('site is not allowed');
+    });
+
+    it('resolves tenant-authorized accounts inside tenant context', async () => {
+        await expect(runWithTenant(tenant, () => resolveAccount('sc-domain:a.example', 'google')))
+            .resolves.toMatchObject({ id: 'tenant_google' });
+    });
+
+    it('preserves legacy global fallback outside tenant context', async () => {
+        await expect(resolveAccount('sc-domain:unknown.example', 'google'))
+            .resolves.toMatchObject({ id: 'global_google' });
+    });
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -38,21 +38,30 @@ describe('Sites Tools', () => {
         mockSearchConsoleClient.sites.add.mockResolvedValue({});
         const result = await addSite('https://example.com');
         expect(result).toContain('Successfully added site');
-        expect(mockSearchConsoleClient.sites.add).toHaveBeenCalledWith({ siteUrl: 'https://example.com' });
+        expect(mockSearchConsoleClient.sites.add).toHaveBeenCalledWith(
+            { siteUrl: 'https://example.com' },
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 
     it('should delete a site', async () => {
         mockSearchConsoleClient.sites.delete.mockResolvedValue({});
         const result = await deleteSite('https://example.com');
         expect(result).toContain('Successfully deleted site');
-        expect(mockSearchConsoleClient.sites.delete).toHaveBeenCalledWith({ siteUrl: 'https://example.com' });
+        expect(mockSearchConsoleClient.sites.delete).toHaveBeenCalledWith(
+            { siteUrl: 'https://example.com' },
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 
     it('should get a site', async () => {
         mockSearchConsoleClient.sites.get.mockResolvedValue({ data: { siteUrl: 'https://example.com', permissionLevel: 'siteOwner' } });
         const result = await getSite('https://example.com');
         expect(result).toEqual({ siteUrl: 'https://example.com', permissionLevel: 'siteOwner' });
-        expect(mockSearchConsoleClient.sites.get).toHaveBeenCalledWith({ siteUrl: 'https://example.com' });
+        expect(mockSearchConsoleClient.sites.get).toHaveBeenCalledWith(
+            { siteUrl: 'https://example.com' },
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 });
 
@@ -67,7 +76,10 @@ describe('Sitemaps Tools', () => {
         });
         const sitemaps = await listSitemaps('https://example.com');
         expect(sitemaps).toEqual([{ path: 'https://example.com/sitemap.xml' }]);
-        expect(mockSearchConsoleClient.sitemaps.list).toHaveBeenCalledWith({ siteUrl: 'https://example.com' });
+        expect(mockSearchConsoleClient.sitemaps.list).toHaveBeenCalledWith(
+            { siteUrl: 'https://example.com' },
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 
     it('should list sitemaps with empty result', async () => {
@@ -82,20 +94,26 @@ describe('Sitemaps Tools', () => {
         mockSearchConsoleClient.sitemaps.submit.mockResolvedValue({});
         const result = await submitSitemap('https://example.com', 'https://example.com/sitemap.xml');
         expect(result).toContain('Successfully submitted sitemap');
-        expect(mockSearchConsoleClient.sitemaps.submit).toHaveBeenCalledWith({
-            siteUrl: 'https://example.com',
-            feedpath: 'https://example.com/sitemap.xml'
-        });
+        expect(mockSearchConsoleClient.sitemaps.submit).toHaveBeenCalledWith(
+            {
+                siteUrl: 'https://example.com',
+                feedpath: 'https://example.com/sitemap.xml'
+            },
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 
     it('should delete sitemap', async () => {
         mockSearchConsoleClient.sitemaps.delete.mockResolvedValue({});
         const result = await deleteSitemap('https://example.com', 'https://example.com/sitemap.xml');
         expect(result).toContain('Successfully deleted sitemap');
-        expect(mockSearchConsoleClient.sitemaps.delete).toHaveBeenCalledWith({
-            siteUrl: 'https://example.com',
-            feedpath: 'https://example.com/sitemap.xml'
-        });
+        expect(mockSearchConsoleClient.sitemaps.delete).toHaveBeenCalledWith(
+            {
+                siteUrl: 'https://example.com',
+                feedpath: 'https://example.com/sitemap.xml'
+            },
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 
     it('should get sitemap', async () => {
@@ -103,10 +121,13 @@ describe('Sitemaps Tools', () => {
         mockSearchConsoleClient.sitemaps.get.mockResolvedValue({ data: mockSitemap });
         const result = await getSitemap('https://example.com', 'https://example.com/sitemap.xml');
         expect(result).toEqual(mockSitemap);
-        expect(mockSearchConsoleClient.sitemaps.get).toHaveBeenCalledWith({
-            siteUrl: 'https://example.com',
-            feedpath: 'https://example.com/sitemap.xml'
-        });
+        expect(mockSearchConsoleClient.sitemaps.get).toHaveBeenCalledWith(
+            {
+                siteUrl: 'https://example.com',
+                feedpath: 'https://example.com/sitemap.xml'
+            },
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 });
 
@@ -129,13 +150,16 @@ describe('Analytics Tools', () => {
         });
 
         expect(result).toEqual(mockRows);
-        expect(mockSearchConsoleClient.searchanalytics.query).toHaveBeenCalledWith(expect.objectContaining({
-            siteUrl: 'https://example.com',
-            requestBody: expect.objectContaining({
-                startDate: '2023-01-01',
-                endDate: '2023-01-31'
-            })
-        }));
+        expect(mockSearchConsoleClient.searchanalytics.query).toHaveBeenCalledWith(
+            expect.objectContaining({
+                siteUrl: 'https://example.com',
+                requestBody: expect.objectContaining({
+                    startDate: '2023-01-01',
+                    endDate: '2023-01-31'
+                })
+            }),
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 
     it('should query analytics with empty results', async () => {
@@ -166,13 +190,16 @@ describe('Analytics Tools', () => {
         });
 
         expect(result).toEqual(mockRows);
-        expect(mockSearchConsoleClient.searchanalytics.query).toHaveBeenCalledWith(expect.objectContaining({
-            requestBody: expect.objectContaining({
-                dimensionFilterGroups: [{
-                    filters: [{ dimension: 'query', operator: 'contains', expression: 'test' }]
-                }]
-            })
-        }));
+        expect(mockSearchConsoleClient.searchanalytics.query).toHaveBeenCalledWith(
+            expect.objectContaining({
+                requestBody: expect.objectContaining({
+                    dimensionFilterGroups: [{
+                        filters: [{ dimension: 'query', operator: 'contains', expression: 'test' }]
+                    }]
+                })
+            }),
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 
     it('should query analytics with startRow for pagination', async () => {
@@ -189,11 +216,14 @@ describe('Analytics Tools', () => {
         });
 
         expect(result).toEqual(mockRows);
-        expect(mockSearchConsoleClient.searchanalytics.query).toHaveBeenCalledWith(expect.objectContaining({
-            requestBody: expect.objectContaining({
-                startRow: 100
-            })
-        }));
+        expect(mockSearchConsoleClient.searchanalytics.query).toHaveBeenCalledWith(
+            expect.objectContaining({
+                requestBody: expect.objectContaining({
+                    startRow: 100
+                })
+            }),
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 
     it('should get performance summary', async () => {
@@ -416,13 +446,16 @@ describe('Inspection Tools', () => {
         const result = await inspectUrl('https://example.com', 'https://example.com/page');
 
         expect(result).toEqual(mockResponse);
-        expect(mockSearchConsoleClient.urlInspection.index.inspect).toHaveBeenCalledWith({
-            requestBody: {
-                inspectionUrl: 'https://example.com/page',
-                siteUrl: 'https://example.com',
-                languageCode: 'en-US'
-            }
-        });
+        expect(mockSearchConsoleClient.urlInspection.index.inspect).toHaveBeenCalledWith(
+            {
+                requestBody: {
+                    inspectionUrl: 'https://example.com/page',
+                    siteUrl: 'https://example.com',
+                    languageCode: 'en-US'
+                }
+            },
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 
     it('should inspect url with custom language code', async () => {
@@ -434,12 +467,15 @@ describe('Inspection Tools', () => {
         const result = await inspectUrl('https://example.com', 'https://example.com/page', 'de-DE');
 
         expect(result).toEqual(mockResponse);
-        expect(mockSearchConsoleClient.urlInspection.index.inspect).toHaveBeenCalledWith({
-            requestBody: {
-                inspectionUrl: 'https://example.com/page',
-                siteUrl: 'https://example.com',
-                languageCode: 'de-DE'
-            }
-        });
+        expect(mockSearchConsoleClient.urlInspection.index.inspect).toHaveBeenCalledWith(
+            {
+                requestBody: {
+                    inspectionUrl: 'https://example.com/page',
+                    siteUrl: 'https://example.com',
+                    languageCode: 'de-DE'
+                }
+            },
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
     });
 });


### PR DESCRIPTION
## Summary

This PR adds an opt-in tenant-security layer for agency-style deployments where one MCP server hosts credentials for multiple clients. The core authorization order is now:

```text
Bearer token -> tenant context -> allowed tools/sites/engines -> tenant-scoped account resolver -> upstream credentials/API
```

Tenant mode is opt-in via `MCP_REQUIRE_TENANT_TOKEN=true` or `MCP_PRODUCTION_MODE=true`, so existing stdio and single-user behavior remains unchanged by default.

## What Changed

### Tenant auth and registry
- Added file-backed tenant and token registries.
- Stores only `sha256:<hex>` bearer token hashes.
- Resolves bearer tokens to enabled tenants before MCP dispatch.
- Added tenant CLI commands:
  - `tenants list`
  - `tenants validate`
  - `tenants add`
  - `tokens create`
  - `tokens revoke`

### Streamable HTTP transport
- Added authenticated `/mcp` Streamable HTTP mode.
- Requires bearer auth in tenant/production mode.
- Binds to `127.0.0.1` by default.
- Refuses public wildcard binds in production unless explicitly overridden.
- Revalidates bearer auth on each request and attaches tenant context to MCP execution.
- Creates a fresh MCP server per Streamable HTTP session when started with a server factory, avoiding cross-session initialization conflicts.

### Central authorization guard
- Added central guard functions for tools, engines, Google/Bing sites, GA4 properties, URLs, sitemaps, and URL batches.
- Mutating tools are disabled by default and require explicit tenant config.
- Account management tools require admin tenant context.
- `sites_list` is tenant-filtered and no longer reveals global account inventory in tenant mode.

### Tenant-scoped account resolution
- Added `resolveTenantAccount`.
- In tenant context, `resolveAccount` delegates to tenant-aware resolution.
- Tenant resolution checks site/property allowlists first, then searches only tenant-listed account IDs.
- Google/Bing/GA4 clients reject account IDs outside the tenant and block legacy env/global fallback inside tenant context.

### Secret handling and SSRF hardening
- Added redaction for bearer tokens, API keys, token hashes, private keys, refresh/access tokens, and client secrets in logs/errors.
- Sanitized MCP error output.
- Hardened `schema_validate` URL mode:
  - only HTTP/HTTPS
  - blocks localhost/private/link-local/metadata hosts
  - applies timeout
  - limits response size
  - tenant mode still requires URL to belong to an allowed tenant site
- IndexNow keys are server-side tenant secrets in tenant mode; client-supplied `key` is rejected.
- PageSpeed API keys can be loaded from server-side env or key files.

## Security Issues Addressed
- Prevents global account fallback from bypassing tenant isolation.
- Prevents account-management tools from being normal tenant tools.
- Prevents `sites_list` from leaking global inventory.
- Removes IndexNow keys from MCP tool arguments in tenant mode.
- Prevents raw upstream/auth errors from leaking secrets.
- Redacts Bing API keys from error/log paths.
- Reduces `schema_validate` SSRF risk for HTTP deployments.

## Tests
- Added tenant registry tests.
- Added tenant guard tests.
- Added tenant resolver isolation tests.
- Added HTTP auth integration coverage.
- Added Streamable HTTP multi-session regression coverage.
- Added redaction tests.
- Added schema validator SSRF tests.
- Updated existing schema validator tests for the safer fetch path.

Verified locally:
- `npm run build`
- `npm test` (`339` tests passing)
- `npm audit --omit=dev` (`0` vulnerabilities)

## Backward Compatibility
Tenant mode is disabled unless explicitly enabled. Existing stdio use and legacy single-account behavior should continue to work outside tenant context.

## Notes for PR #67
[PR #67](https://github.com/saurabhsharma2u/search-console-mcp/pull/67) adds a shared CLI router and compatibility dispatcher. This branch keeps tenant CLI/bootstrap changes small and localized. If #67 merges first, the tenant CLI dispatch can be moved into the new shared CLI router with minimal behavior changes.