### PR TITLE
fix(google/client): use webmasters write scope so sitemaps_submit and sitemaps_delete work

### DIFF
--- a/src/google/client.ts
+++ b/src/google/client.ts
@@ -6,7 +6,7 @@ import { logger } from '../utils/logger.js';
 const { machineIdSync } = nodeMachineId;
 
 const SCOPES = [
-  'https://www.googleapis.com/auth/webmasters.readonly',
+  'https://www.googleapis.com/auth/webmasters',
   'https://www.googleapis.com/auth/userinfo.email'
 ];
 const SERVICE_NAME = 'io.github.saurabhsharma2u.search-console-mcp';
@@ -114,7 +114,7 @@ let cachedIndexingClientMap: Record<string, any> = {};
 
 /**
  * Get an authenticated client for the Google Indexing API.
- * Uses the `indexing` scope which is separate from the read-only `webmasters.readonly` scope.
+ * Uses the `indexing` scope, which is separate from the `webmasters` scope used by the Search Console client.
  *
  * @param siteUrl - The site URL to resolve the account for.
  * @param accountId - Optional specific account ID to use.

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -253,12 +253,12 @@ export async function login() {
     const useIndexing = authorizeIndexing.toLowerCase().startsWith('y');
     const scopes = useIndexing
         ? [
-            'https://www.googleapis.com/auth/webmasters.readonly',
+            'https://www.googleapis.com/auth/webmasters',
             'https://www.googleapis.com/auth/indexing',
             'https://www.googleapis.com/auth/userinfo.email'
           ]
         : [
-            'https://www.googleapis.com/auth/webmasters.readonly',
+            'https://www.googleapis.com/auth/webmasters',
             'https://www.googleapis.com/auth/userinfo.email'
           ];
 


### PR DESCRIPTION
## Summary

The Google client `SCOPES` constant in `src/google/client.ts` is hardcoded to `https://www.googleapis.com/auth/webmasters.readonly`. That's a read-only scope, but the MCP exposes write tools (`sitemaps_submit`, `sitemaps_delete`) — so every write call fails with HTTP 403 `Permission denied`, even when the configured service account or OAuth user has been granted **siteOwner** on the GSC property via the Users panel.

This PR swaps the read-only scope for the broader read+write `https://www.googleapis.com/auth/webmasters` scope. Read functionality continues to work (the broader scope encompasses both), and the previously-broken write tools now succeed.

## Reproduction

1. Configure a service account as siteOwner of a GSC Domain property.
2. Configure the MCP per `docs/setup` with that SA's JSON.
3. Call `sitemaps_submit` with `siteUrl: sc-domain:<your-domain>` and `feedpath: https://<your-domain>/sitemap.xml`.

**Before this PR:** `Error: Permission denied. Ensure you have access to this resource in Google Search Console.` (HTTP 403)

**After this PR:** Sitemap accepted; `sitemaps_list` immediately shows `lastDownloaded` populated.

## Changes

- **`src/google/client.ts`** — Swap the read-only scope in the runtime `SCOPES` const for the read+write scope. Update the doc comment on `getIndexingClient` to drop the no-longer-accurate "read-only" qualifier in the cross-reference to the webmasters scope.
- **`src/setup.ts`** — Same swap in the OAuth Desktop Flow setup wizard, both branches of the `useIndexing` Y/N conditional, so users who set up via `scmcp setup` also get the write scope by default. The "Would you like to also authorize Google Indexing API write scope?" prompt is preserved verbatim — only the bundled `webmasters` scope changes.

## What is NOT changed

- The two probe helpers (`testConnection` and the SA site-list helper around `src/setup.ts:404`) keep the read-only scope. Both genuinely only need read access (one tests credentials, the other just lists sites), and minimizing requested scope on a probe is correct.
- The separate `indexing` scope used by `getIndexingClient` is unchanged.
- No test expectations changed; all 342 tests across 48 files continue to pass on this branch.

## Migration note for existing users

Existing OAuth refresh tokens minted with `webmasters.readonly` will continue to work for read-only tools after the upgrade. To enable the write tools, those users will need to re-run `scmcp setup` and re-consent to the broader scope. Service-account users see no auth flow change — the broader scope is requested transparently on the next JWT signing.

## Verification

- `npm run build` — clean tsc compile.
- `npm test` — 342/342 tests pass (48 files).
- End-to-end: `sitemaps_submit` against a real GSC Domain property succeeds; `sitemaps_list` confirms `lastDownloaded` within ~1 second.