### PR TITLE
fix: remove duplicate prompt and tool registrations on startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -341,8 +341,6 @@ registerTool(
   healthFluent.compareEnginesHandler
 );
 
-registerPrompts(server);
-
 registerTool(
   "diagnostics",
   "Run connectivity diagnostics for all connected accounts. Use this to troubleshoot '0 results' or authentication issues.",
@@ -370,28 +368,6 @@ registerTool(
   }
   return await registeredTool.handler(request.params.arguments);
 });
-
-registerPrompts(server);
-
-registerTool(
-  "analytics_anomalies",
-  "Identify unusual daily spikes or drops in traffic.",
-  {
-    siteUrl: z.string().describe("The URL of the site"),
-    days: z.number().optional().describe("Number of days to look back for baseline (default: 30)"),
-    threshold: z.number().optional().describe("Sensitivity threshold (Standard Deviations, default: 2.5)")
-  },
-  async ({ siteUrl, days, threshold }) => {
-    try {
-      const result = await analytics.detectAnomalies(siteUrl, { days, threshold });
-      return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
-      };
-    } catch (error) {
-      return formatError(error);
-    }
-  }
-);
 
 registerTool(
   "analytics_drop_attribution",
@@ -456,29 +432,6 @@ registerTool(
 
 // Inspection Tools
 registerTool(
-  "inspection_inspect",
-  "Inspect a URL to check its indexing status, crawl info, and health",
-  {
-    siteUrl: z.string().describe("The URL of the property"),
-    inspectionUrl: z.string().describe("The fully-qualified URL to inspect"),
-    languageCode: z.string().optional().describe("Language code for localized results (Google only)"),
-    engine: z.enum(["google", "bing"]).optional().describe("The search engine (default: google)")
-  },
-  async ({ siteUrl, inspectionUrl, languageCode, engine = "google" }) => {
-    try {
-      const result = engine === "google"
-        ? await inspection.inspectUrl(siteUrl, inspectionUrl, languageCode)
-        : await bingInspection.getUrlInfo(siteUrl, inspectionUrl);
-      return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
-      };
-    } catch (error) {
-      return formatError(error);
-    }
-  }
-);
-
-registerTool(
   "inspection_batch",
   "Inspect multiple URLs for a site in batch",
   {
@@ -507,25 +460,6 @@ registerTool(
 );
 
 // PageSpeed Insights Tools
-registerTool(
-  "pagespeed_analyze",
-  "Run PageSpeed Insights analysis on a URL to get performance, accessibility, best practices, and SEO scores",
-  {
-    url: z.string().describe("The URL to analyze"),
-    strategy: z.enum(["mobile", "desktop"]).optional().describe("Device strategy (default: mobile)")
-  },
-  async ({ url, strategy }) => {
-    try {
-      const result = await pagespeed.analyzePageSpeed(url, strategy || 'mobile');
-      return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
-      };
-    } catch (error) {
-      return formatError(error);
-    }
-  }
-);
-
 registerTool(
   "pagespeed_core_web_vitals",
   "Get Core Web Vitals for both mobile and desktop including LCP, FID, CLS, FCP, TTI, and TBT",
@@ -865,26 +799,6 @@ registerTool(
     return {
       content: [{ type: "text", text: JSON.stringify(seoPrimitives.isCannibalized(query, pageA, pageB), null, 2) }]
     };
-  }
-);
-
-// Schema Validator Tools
-registerTool(
-  "schema_validate",
-  "Validate Schema.org structured data (JSON-LD) from a URL, HTML snippet, or JSON object.",
-  {
-    type: z.enum(["url", "html", "json"]).describe("The type of input provided"),
-    data: z.string().describe("The URL, HTML content, or JSON string to validate")
-  },
-  async ({ type, data }) => {
-    try {
-      const result = await schemaValidator.validateSchema(data, type as 'url' | 'html' | 'json');
-      return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
-      };
-    } catch (error) {
-      return formatError(error);
-    }
   }
 );
 
@@ -1349,25 +1263,6 @@ registerTool(
   async ({ siteUrl, url }) => {
     try {
       const result = await googleIndexing.publishNotification(siteUrl, url, 'URL_DELETED');
-      return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
-      };
-    } catch (error) {
-      return formatError(error);
-    }
-  }
-);
-
-registerTool(
-  "indexing_status",
-  "Check the notification status for a URL previously submitted to the Google Indexing API",
-  {
-    siteUrl: z.string().describe("The property URL as registered in Search Console"),
-    url: z.string().describe("The URL to check notification status for")
-  },
-  async ({ siteUrl, url }) => {
-    try {
-      const result = await googleIndexing.getNotificationStatus(siteUrl, url);
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
       };
@@ -2443,25 +2338,6 @@ If any site has a 'critical' or 'warning' status:
         }
       }]
     };
-  }
-);
-
-registerPrompts(server);
-
-// Diagnostics Tool
-registerTool(
-  "diagnostics",
-  "Run connectivity diagnostics for all connected accounts. Use this to troubleshoot '0 results' or authentication issues.",
-  {},
-  async () => {
-    try {
-      const results = await runDiagnostics();
-      return {
-        content: [{ type: "text", text: JSON.stringify(results, null, 2) }]
-      };
-    } catch (error) {
-      return formatError(error);
-    }
   }
 );
 

--- a/tests/server-bootstrap.test.ts
+++ b/tests/server-bootstrap.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { execSync, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("server bootstrap", () => {
+  beforeAll(() => {
+    execSync("npm run build", { cwd: projectRoot, stdio: "pipe" });
+  }, 120_000);
+
+  it("starts without duplicate prompt/tool registration errors", async () => {
+    const entry = path.join(projectRoot, "dist/index.js");
+    const child = spawn(process.execPath, [entry], {
+      cwd: projectRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+
+    let stderr = "";
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const startedAt = Date.now();
+      const interval = setInterval(() => {
+        if (stderr.includes("is already registered")) {
+          clearInterval(interval);
+          clearTimeout(timeout);
+          child.kill();
+          reject(new Error(stderr));
+          return;
+        }
+
+        if (stderr.includes("Search Console MCP running on stdio")) {
+          clearInterval(interval);
+          clearTimeout(timeout);
+          child.kill();
+          resolve();
+          return;
+        }
+
+        if (Date.now() - startedAt > 10_000) {
+          clearInterval(interval);
+          clearTimeout(timeout);
+          child.kill();
+          reject(new Error(`Timed out waiting for server start. stderr: ${stderr}`));
+        }
+      }, 100);
+
+      const timeout = setTimeout(() => {
+        clearInterval(interval);
+        child.kill();
+        reject(new Error(`Timed out waiting for server start. stderr: ${stderr}`));
+      }, 10_500);
+
+      child.on("exit", (code) => {
+        if (code !== null && code !== 0) {
+          clearInterval(interval);
+          clearTimeout(timeout);
+          reject(new Error(`Process exited with code ${code}: ${stderr}`));
+        }
+      });
+    });
+
+    expect(stderr).toContain("Search Console MCP running on stdio");
+    expect(stderr).not.toMatch(/is already registered/);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- Fixes a startup crash in `search-console-mcp@2.0.0` caused by duplicate MCP registrations during module initialization
- Removes three extra `registerPrompts(server)` calls and one duplicate `diagnostics` tool registration
- Removes five legacy tool registrations that duplicated the fluent v2 tools (`analytics_anomalies`, `inspection_inspect`, `pagespeed_analyze`, `schema_validate`, `indexing_status`)
- Adds `tests/server-bootstrap.test.ts` to verify the server process starts without duplicate-registration errors

## Problem

Since v2.0.0, the server fails immediately on launch with:

```
Error: Prompt investigate_traffic_drop is already registered
```

After resolving prompt duplicates, the same class of bug appears for tools such as `analytics_anomalies`.

The MCP SDK throws when a prompt or tool name is registered more than once.

## Root cause

During the fluent-tools consolidation in v2.0.0, registration blocks were copied into `src/index.ts` without removing the existing ones further down in the file.

## Fix

- Keep a single `registerPrompts(server)` call during server initialization
- Keep the fluent v2 tool registrations as the canonical implementations
- Retain legacy tool names via the existing `legacyFallbackMap` where applicable
- Add a subprocess smoke test that waits for the stdio startup message

## Test plan

- [x] `npm run build`
- [x] `npm test` (436 tests passing, including bootstrap smoke test)
- [x] `node dist/index.js` starts and prints `Search Console MCP running on stdio`


Made with [Cursor](https://cursor.com)