### PR TITLE
fix: stop legacy fallback shims from shadowing registered tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ import * as inspectionFluent from "./tools/fluent/inspection.js";
 import * as indexingFluent from "./tools/fluent/indexing.js";
 import * as seoFluent from "./tools/fluent/seo.js";
 import * as healthFluent from "./tools/fluent/health.js";
-import { executeLegacyFallback, legacyFallbackMap } from "./legacy/fallback-router.js";
+import { executeLegacyFallback, legacyFallbackMap, shouldUseLegacyFallback } from "./legacy/fallback-router.js";
 import { CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 
 
@@ -357,14 +357,20 @@ registerTool(
   }
 );
 
-// Internal silent fallback router interceptor for CallTool requests
+// Internal silent fallback router interceptor for CallTool requests.
+//
+// Registered tools take priority. Ten legacy keys share a name with a modern
+// tool, and the legacy shims accept a different argument shape, so checking the
+// fallback map first left those tools permanently calling the wrong handler
+// with mangled arguments. Legacy names are aliases only for tools that are not
+// registered under the current schema.
 (server.server as any).setRequestHandler(CallToolRequestSchema, async (request: any, extra: any) => {
   const toolName = request.params.name;
-  if (legacyFallbackMap[toolName]) {
+  const registeredTool = (server as any)._registeredTools[toolName];
+  if (shouldUseLegacyFallback(toolName, Boolean(registeredTool))) {
     const legacyResult = await executeLegacyFallback(toolName, request.params.arguments);
     if (legacyResult) return legacyResult;
   }
-  const registeredTool = (server as any)._registeredTools[toolName];
   if (!registeredTool) {
     throw new Error(`Tool ${toolName} not found`);
   }

--- a/src/legacy/fallback-router.ts
+++ b/src/legacy/fallback-router.ts
@@ -109,3 +109,22 @@ export async function executeLegacyFallback(name: string, args: any): Promise<an
   if (!handler) return null;
   return await handler(args);
 }
+
+/**
+ * Decide whether a CallTool request should be served by the legacy fallback map.
+ *
+ * A registered tool always wins. Several legacy keys share a name with a modern
+ * tool but accept a different argument shape (for example `inspection_inspect`
+ * reads a singular `url` while the registered tool takes a `urls` array, and the
+ * analytics/sites/sitemaps shims hardcode `engine: "google"`). Consulting the
+ * fallback map first would route those calls to a handler that silently drops or
+ * misreads the caller's arguments.
+ *
+ * @param toolName - The requested tool name.
+ * @param isRegistered - Whether a tool of that name is registered on the server.
+ * @returns True when the legacy shim should handle the request.
+ */
+export function shouldUseLegacyFallback(toolName: string, isRegistered: boolean): boolean {
+  if (isRegistered) return false;
+  return Boolean(legacyFallbackMap[toolName]);
+}

--- a/tests/legacy-fallback-dispatch.test.ts
+++ b/tests/legacy-fallback-dispatch.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { legacyFallbackMap, shouldUseLegacyFallback } from "../src/legacy/fallback-router.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Tool names registered via registerTool(...) in src/index.ts.
+ *
+ * Read from source rather than hardcoded so the collision list below stays
+ * accurate as tools are added or renamed.
+ */
+function registeredToolNames(): string[] {
+  const src = readFileSync(join(__dirname, "../src/index.ts"), "utf8");
+  return [...src.matchAll(/registerTool\(\s*"([^"]+)"/g)].map((m) => m[1]);
+}
+
+describe("legacy fallback dispatch order", () => {
+  it("never lets a legacy shim shadow a registered tool", () => {
+    for (const name of registeredToolNames()) {
+      expect(
+        shouldUseLegacyFallback(name, true),
+        `legacy shim must not handle registered tool "${name}"`
+      ).toBe(false);
+    }
+  });
+
+  it("still resolves legacy-only aliases", () => {
+    const registered = new Set(registeredToolNames());
+    const legacyOnly = Object.keys(legacyFallbackMap).filter((n) => !registered.has(n));
+
+    expect(legacyOnly.length).toBeGreaterThan(0);
+    for (const name of legacyOnly) {
+      expect(shouldUseLegacyFallback(name, false), `legacy alias "${name}" must resolve`).toBe(true);
+    }
+  });
+
+  it("rejects names that are neither registered nor legacy", () => {
+    expect(shouldUseLegacyFallback("definitely_not_a_tool", false)).toBe(false);
+  });
+
+  /**
+   * Regression guard for the tools that regressed in 2.0.2. Each of these names
+   * exists in both the registered set and the legacy map, and the legacy shim
+   * takes a different argument shape:
+   *
+   *  - inspection_inspect reads a singular `url`; the tool takes `urls: string[]`,
+   *    so the shim sent `inspectionUrl: undefined` to Google, which answered
+   *    "You do not own this site, or the inspected URL is not part of this
+   *    property" for sites the caller did in fact own.
+   *  - analytics_query / sites_list / sitemaps_list / analytics_anomalies hardcode
+   *    `engine: "google"`, so every Bing request ran against Google instead.
+   */
+  it("keeps the known-colliding tools on their registered handlers", () => {
+    const knownCollisions = [
+      "analytics_anomalies",
+      "analytics_query",
+      "compare_engines",
+      "indexing_status",
+      "inspection_inspect",
+      "pagespeed_analyze",
+      "sitemaps_delete",
+      "sitemaps_list",
+      "sitemaps_submit",
+      "sites_list",
+    ];
+
+    const registered = new Set(registeredToolNames());
+    for (const name of knownCollisions) {
+      expect(registered.has(name), `${name} should still be a registered tool`).toBe(true);
+      expect(legacyFallbackMap[name], `${name} should still exist as a legacy alias`).toBeDefined();
+      expect(shouldUseLegacyFallback(name, true)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The `CallToolRequestSchema` interceptor in `src/index.ts` checks `legacyFallbackMap` **before** the registered tool table:

```ts
if (legacyFallbackMap[toolName]) {
  const legacyResult = await executeLegacyFallback(toolName, request.params.arguments);
  if (legacyResult) return legacyResult;   // always returns; shim wins
}
const registeredTool = (server as any)._registeredTools[toolName];   // unreachable for colliding names
```

`executeLegacyFallback` returns the shim's result unconditionally whenever the key exists, so it always short-circuits. Ten tool names exist in both maps, and the legacy shims accept a different argument shape than the current schemas, so those ten tools have been calling the wrong handler with mangled arguments:

`analytics_anomalies`, `analytics_query`, `compare_engines`, `indexing_status`, `inspection_inspect`, `pagespeed_analyze`, `sitemaps_delete`, `sitemaps_list`, `sitemaps_submit`, `sites_list`

## User-visible impact

**1. `inspection_inspect` is completely broken.**

The registered tool takes `urls: string[]`. The shim reads the singular `args.url`:

```ts
inspection_inspect: (args) => inspectionFluent.inspectionInspectHandler({
  siteUrl: args.siteUrl, urls: [args.url], engine: "google" }),
```

So a valid call becomes `urls: [undefined]`, and Google receives `inspectionUrl: undefined`. Google answers with:

> You do not own this site, or the inspected URL is not part of this property.

That reads as an ownership or OAuth-scope failure, which sends people off re-verifying properties and re-checking scopes. The property is fine and `webmasters.readonly` is correct for `urlInspection.index.inspect`; only the second clause of Google's message is the accurate one. I lost a while to this on a `sc-domain:` property where `analytics_query` and `sitemaps_list` worked perfectly against the same account.

**2. Bing is unreachable through the unified tools.**

The analytics, sites, and sitemaps shims hardcode `engine: "google"` and drop the caller's `engine`:

```ts
sites_list:      (args) => sitesFluent.sitesListHandler({ engine: "google" }),
analytics_query: (args) => analyticsFluent.analyticsQueryHandler({ ..., engine: "google" }),
```

So `analytics_query` with `engine: "bing"` silently queries **Google** (and returns a confusing Google permission error if you passed a Bing-style `https://example.com/` identifier), and `sites_list` with `engine: "all"` returns Google properties only, while `diagnostics` correctly reports the Bing account as connected with N sites. `compare_engines` returns empty rows for the same reason.

`diagnostics` and `sites_manage` are not in the legacy map, which is exactly why they behave correctly today.

## Fix

Registered tools take priority. Legacy names remain aliases for tools that are not registered under the current schema, so genuine legacy-only names (`analytics_top_queries`, `bing_analytics_query`, `indexing_submit_url`, and the rest) are unaffected.

The decision moves into an exported `shouldUseLegacyFallback(toolName, isRegistered)` helper in `src/legacy/fallback-router.ts` so it can be tested without booting the server.

## Tests

Adds `tests/legacy-fallback-dispatch.test.ts` (4 tests):

- no registered tool can be shadowed (tool names are parsed from `src/index.ts`, so the guard stays accurate as tools are added)
- legacy-only aliases still resolve
- unknown names resolve to neither
- the ten known-colliding names stay on their registered handlers

I confirmed the test fails when the dispatch order is reverted, then passes with the fix.

Full suite: **439 tests across 61 files, all passing.** `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registered tools now always take precedence over legacy aliases.
  * Prevented legacy fallbacks from intercepting tools with incompatible argument requirements.
  * Unknown tool names continue to be rejected.

* **Tests**
  * Added coverage for registered tools, legacy-only aliases, unknown names, and conflicting tool names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->