### PR TITLE
perf: Fix startup timeout by lazy loading heavy dependencies

### DIFF
--- a/src/common/auth/config.ts
+++ b/src/common/auth/config.ts
@@ -1,10 +1,11 @@
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { createCipheriv, createDecipheriv, scryptSync, randomBytes } from 'crypto';
-import nodeMachineId from 'node-machine-id';
+import { createCipheriv, createDecipheriv, scrypt, randomBytes } from 'crypto';
+import { promisify } from 'util';
+import { machineId } from 'node-machine-id';
 
-const { machineIdSync } = nodeMachineId;
+const scryptAsync = promisify(scrypt);
 
 const CONFIG_PATH = join(homedir(), '.search-console-mcp-config.enc');
 const LEGACY_TOKEN_PATH = join(homedir(), '.search-console-mcp-tokens.enc');
@@ -45,19 +46,19 @@ export function resetConfigCache() {
     cachedEncryptionKey = null;
 }
 
-function getEncryptionKey(): Buffer {
+async function getEncryptionKey(): Promise<Buffer> {
     if (cachedEncryptionKey) {
         return cachedEncryptionKey;
     }
-    const mId = machineIdSync();
+    const mId = await machineId(false);
     const salt = process.env.USER || 'sc-mcp-salt';
-    cachedEncryptionKey = scryptSync(mId, salt, 32);
+    cachedEncryptionKey = (await scryptAsync(mId, salt, 32)) as Buffer;
     return cachedEncryptionKey;
 }
 
-function encrypt(text: string): string {
+async function encrypt(text: string): Promise<string> {
     const iv = randomBytes(12);
-    const key = getEncryptionKey();
+    const key = await getEncryptionKey();
     const cipher = createCipheriv(ENCRYPTION_ALGORITHM, key, iv);
     let encrypted = cipher.update(text, 'utf8', 'hex');
     encrypted += cipher.final('hex');
@@ -65,11 +66,11 @@ function encrypt(text: string): string {
     return `${iv.toString('hex')}:${authTag}:${encrypted}`;
 }
 
-function decrypt(data: string): string {
+async function decrypt(data: string): Promise<string> {
     const [ivHex, authTagHex, encryptedHex] = data.split(':');
     const iv = Buffer.from(ivHex, 'hex');
     const authTag = Buffer.from(authTagHex, 'hex');
-    const key = getEncryptionKey();
+    const key = await getEncryptionKey();
     const decipher = createDecipheriv(ENCRYPTION_ALGORITHM, key, iv);
     decipher.setAuthTag(authTag);
     let decrypted = decipher.update(encryptedHex, 'hex', 'utf8');
@@ -91,7 +92,7 @@ export async function loadConfig(): Promise<AppConfig> {
     if (existsSync(CONFIG_PATH)) {
         try {
             const encryptedData = readFileSync(CONFIG_PATH, 'utf-8');
-            const decrypted = decrypt(encryptedData);
+            const decrypted = await decrypt(encryptedData);
             config = JSON.parse(decrypted);
         } catch (e) {
             console.error('Failed to load unified config:', (e as Error).message);
@@ -102,7 +103,7 @@ export async function loadConfig(): Promise<AppConfig> {
     if (existsSync(LEGACY_TOKEN_PATH)) {
         try {
             const encryptedData = readFileSync(LEGACY_TOKEN_PATH, 'utf-8');
-            const decrypted = decrypt(encryptedData);
+            const decrypted = await decrypt(encryptedData);
             const googleTokens = JSON.parse(decrypted);
 
             for (const [email, tokens] of Object.entries(googleTokens)) {
@@ -185,7 +186,7 @@ export async function loadConfig(): Promise<AppConfig> {
 
 export async function saveConfig(config: AppConfig) {
     try {
-        const encrypted = encrypt(JSON.stringify(config));
+        const encrypted = await encrypt(JSON.stringify(config));
         writeFileSync(CONFIG_PATH, encrypted, { mode: 0o600 });
         cachedConfig = config;
     } catch (e) {

--- a/src/ga4/client.ts
+++ b/src/ga4/client.ts
@@ -1,5 +1,4 @@
-import { BetaAnalyticsDataClient } from '@google-analytics/data';
-import { google } from 'googleapis';
+import type { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { AccountConfig, loadConfig } from '../common/auth/config.js';
 import { resolveAccount } from '../common/auth/resolver.js';
 import { loadTokensForAccount, saveTokensForAccount, DEFAULT_CLIENT_ID, DEFAULT_CLIENT_SECRET } from '../google/client.js';
@@ -50,6 +49,8 @@ export function clearGA4ClientCache() {
 }
 
 export async function getGA4Client(propertyId?: string, accountId?: string): Promise<GA4Client> {
+    const { BetaAnalyticsDataClient } = await import('@google-analytics/data');
+    const { google } = await import('googleapis');
     // 1. Resolve Account
     let account: AccountConfig | undefined;
     const config = await loadConfig();

--- a/src/google/client.ts
+++ b/src/google/client.ts
@@ -1,4 +1,4 @@
-import { google, searchconsole_v1 } from 'googleapis';
+import type { searchconsole_v1 } from 'googleapis';
 import nodeMachineId from 'node-machine-id';
 import { AccountConfig, loadConfig, saveConfig, updateAccount, removeAccount } from '../common/auth/config.js';
 import { resolveAccount } from '../common/auth/resolver.js';
@@ -21,6 +21,7 @@ export const DEFAULT_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || 'GOCSPX
 let cachedClientMap: Record<string, searchconsole_v1.Searchconsole> = {};
 
 export async function getSearchConsoleClient(siteUrl?: string, accountId?: string): Promise<searchconsole_v1.Searchconsole> {
+  const { google } = await import('googleapis');
   // 1. Resolve Account
   let account: AccountConfig;
   if (accountId) {
@@ -121,6 +122,7 @@ let cachedIndexingClientMap: Record<string, any> = {};
  * @returns An authenticated OAuth2 client with the indexing scope.
  */
 export async function getIndexingClient(siteUrl?: string, accountId?: string): Promise<any> {
+  const { google } = await import('googleapis');
   // 1. Resolve Account
   let account: AccountConfig;
   if (accountId) {
@@ -205,6 +207,7 @@ export async function getIndexingClient(siteUrl?: string, accountId?: string): P
 }
 
 export async function getUserEmail(tokens: any): Promise<string> {
+  const { google } = await import('googleapis');
   const oauth2Client = new google.auth.OAuth2(
     process.env.GOOGLE_CLIENT_ID || DEFAULT_CLIENT_ID,
     process.env.GOOGLE_CLIENT_SECRET || DEFAULT_CLIENT_SECRET

--- a/src/google/tools/analytics.ts
+++ b/src/google/tools/analytics.ts
@@ -1,5 +1,5 @@
 import { getSearchConsoleClient } from '../client.js';
-import { searchconsole_v1 } from 'googleapis';
+import type { searchconsole_v1 } from 'googleapis';
 import { logger } from '../../utils/logger.js';
 import { resolveSiteProperty } from '../../common/auth/resolver.js';
 

--- a/src/google/tools/inspection.ts
+++ b/src/google/tools/inspection.ts
@@ -1,5 +1,5 @@
 import { getSearchConsoleClient } from '../client.js';
-import { searchconsole_v1 } from 'googleapis';
+import type { searchconsole_v1 } from 'googleapis';
 import { limitConcurrency } from '../../common/concurrency.js';
 import { resolveSiteProperty, resolveFullWebUrl } from '../../common/auth/resolver.js';
 

--- a/src/google/tools/pagespeed.ts
+++ b/src/google/tools/pagespeed.ts
@@ -1,7 +1,5 @@
-import { google, pagespeedonline_v5 } from 'googleapis';
+import type { pagespeedonline_v5 } from 'googleapis';
 import { resolveFullWebUrl } from '../../common/auth/resolver.js';
-
-const pagespeed = google.pagespeedonline('v5');
 
 /**
  * Returns the PageSpeed API key from environment, if configured.
@@ -57,6 +55,8 @@ export async function analyzePageSpeed(
     url: string,
     strategy: 'mobile' | 'desktop' = 'mobile'
 ): Promise<PageSpeedResult> {
+    const { google } = await import('googleapis');
+    const pagespeed = google.pagespeedonline('v5');
     const fullUrl = resolveFullWebUrl(url);
     const key = getApiKey();
     let res;

--- a/src/google/tools/sitemaps.ts
+++ b/src/google/tools/sitemaps.ts
@@ -1,5 +1,5 @@
 import { getSearchConsoleClient } from '../client.js';
-import { searchconsole_v1 } from 'googleapis';
+import type { searchconsole_v1 } from 'googleapis';
 import { resolveSiteProperty } from '../../common/auth/resolver.js';
 
 /**

--- a/src/google/tools/sites.ts
+++ b/src/google/tools/sites.ts
@@ -1,5 +1,5 @@
 import { getSearchConsoleClient } from '../client.js';
-import { searchconsole_v1 } from 'googleapis';
+import type { searchconsole_v1 } from 'googleapis';
 
 /**
  * List all sites verified in the specified Google account.

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -8,7 +8,6 @@ import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { startLocalFlow, getUserEmail, logout, getSearchConsoleClient, DEFAULT_CLIENT_ID, DEFAULT_CLIENT_SECRET, saveTokensForAccount } from './google/client.js';
 import { getBingClient, BingClient } from './bing/client.js';
-import { google } from 'googleapis';
 import { loadConfig, updateAccount, AccountConfig } from './common/auth/config.js';
 import { colors, printBoxHeader, printStatusLine } from './utils/ui.js';
 
@@ -53,6 +52,7 @@ function printInfo(text: string) {
 async function selectGA4Property(auth: any): Promise<string | undefined> {
     printInfo('Fetching available GA4 properties...');
     try {
+        const { google } = await import('googleapis');
         const admin = google.analyticsadmin('v1beta');
         const response = await admin.accountSummaries.list({ auth });
 
@@ -274,6 +274,7 @@ export async function login() {
         console.log(`\nAuthorized as: ${colors.bold}${email}${colors.reset}`);
 
         // Fetch and select websites
+        const { google } = await import('googleapis');
         const oauth2Client = new google.auth.OAuth2(clientId, clientSecret);
         oauth2Client.setCredentials(tokens);
         const gClient = google.searchconsole({ version: 'v1', auth: oauth2Client });
@@ -760,6 +761,7 @@ async function setupGA4ServiceAccount() {
 
     await ask('Press Enter when you\'ve added the service account to GA4...');
 
+    const { google } = await import('googleapis');
     const auth = new google.auth.GoogleAuth({
         keyFile: keyPath,
         scopes: ['https://www.googleapis.com/auth/analytics.readonly']
@@ -814,6 +816,7 @@ async function setupGA4OAuth() {
         const email = await getUserEmail(tokens);
         console.log(`\nAuthorized as: ${colors.bold}${email}${colors.reset}`);
 
+        const { google } = await import('googleapis');
         const oauth2Client = new google.auth.OAuth2(clientId, clientSecret);
         oauth2Client.setCredentials(tokens);
 

--- a/tests/auth-config.test.ts
+++ b/tests/auth-config.test.ts
@@ -11,6 +11,7 @@ vi.mock('fs', () => ({
 }));
 
 vi.mock('node-machine-id', () => ({
+    machineId: vi.fn().mockResolvedValue('test-machine-id'),
     default: {
         machineIdSync: vi.fn(() => 'test-machine-id'),
     }

--- a/tests/benchmark_load_config.test.ts
+++ b/tests/benchmark_load_config.test.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 
 // Mock node-machine-id
 vi.mock('node-machine-id', () => ({
+    machineId: () => Promise.resolve('benchmark-machine-id'),
     default: {
         machineIdSync: () => 'benchmark-machine-id'
     }


### PR DESCRIPTION
- Used `import type` for type safety where `googleapis` or `@google-analytics/data` were previously imported.
- Wrapped usages in `await import(...)` in initialization paths (`getSearchConsoleClient`, `getGA4Client`, `getEncryptionKey`, `setup`, etc.).
- Converted `machineIdSync()` to `machineId()` in `src/common/auth/config.ts`.
- Converted `scryptSync` to `promisify(scrypt)`.
- Updated test files to mock the new asynchronous methods for `node-machine-id`.
- Re-tested core setup flows and configuration parsing to ensure no regressions.

---
*PR created automatically by Jules for task [2702213749040285899](https://jules.google.com/task/2702213749040285899) started by @saurabhsharma2u*