### PR TITLE
fix(client): expand '~' in service-account keyFilename before client construction

### DIFF
--- a/src/ga4/client.ts
+++ b/src/ga4/client.ts
@@ -1,6 +1,7 @@
 import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { google } from 'googleapis';
 import { AccountConfig, loadConfig, assertServiceAccountKeyReadable } from '../common/auth/config.js';
+import { expandHome } from '../utils/paths.js';
 import { resolveAccount } from '../common/auth/resolver.js';
 import { loadTokensForAccount, saveTokensForAccount, DEFAULT_CLIENT_ID, DEFAULT_CLIENT_SECRET } from '../google/client.js';
 
@@ -140,7 +141,7 @@ export async function getGA4Client(propertyId?: string, accountId?: string): Pro
     if (account.serviceAccountPath) {
         assertServiceAccountKeyReadable(account);
         client = new BetaAnalyticsDataClient({
-            keyFilename: account.serviceAccountPath
+            keyFilename: expandHome(account.serviceAccountPath)
         });
         const ga4Client = new GA4Client(client, targetPropertyId);
         cacheClient(cacheKey, ga4Client);

--- a/src/google/client.ts
+++ b/src/google/client.ts
@@ -3,6 +3,7 @@ import nodeMachineId from 'node-machine-id';
 import { AccountConfig, findAccountByAliasOrId, loadConfig, saveConfig, updateAccount, removeAccount, assertServiceAccountKeyReadable } from '../common/auth/config.js';
 import { resolveAccount } from '../common/auth/resolver.js';
 import { logger } from '../utils/logger.js';
+import { expandHome } from '../utils/paths.js';
 const { machineIdSync } = nodeMachineId;
 
 const SCOPES = [
@@ -74,7 +75,7 @@ export async function getSearchConsoleClient(siteUrl?: string, accountId?: strin
   if (account.serviceAccountPath) {
     assertServiceAccountKeyReadable(account);
     const auth = new google.auth.GoogleAuth({
-      keyFilename: account.serviceAccountPath,
+      keyFilename: expandHome(account.serviceAccountPath),
       scopes: SCOPES
     });
     const client = google.searchconsole({ version: 'v1', auth });
@@ -173,7 +174,7 @@ export async function getIndexingClient(siteUrl?: string, accountId?: string): P
   if (account.serviceAccountPath) {
     assertServiceAccountKeyReadable(account);
     const auth = new google.auth.GoogleAuth({
-      keyFilename: account.serviceAccountPath,
+      keyFilename: expandHome(account.serviceAccountPath),
       scopes: INDEXING_SCOPES
     });
     const client = await auth.getClient();

--- a/tests/google-client.test.ts
+++ b/tests/google-client.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { homedir } from 'os';
 import { getSearchConsoleClient, startLocalFlow, initiateDeviceFlow, pollForTokens, loadTokensForAccount } from '../src/google/client.js';
 import * as configModule from '../src/common/auth/config.js';
 import * as resolverModule from '../src/common/auth/resolver.js';
@@ -169,6 +171,25 @@ describe('Google Client', () => {
             await getSearchConsoleClient(undefined, accountId);
             expect(MockGoogleAuth).toHaveBeenCalledWith(expect.objectContaining({
                 keyFilename: '/path/to/sa.json'
+            }));
+        });
+
+        it('should expand a leading tilde in the service account path for keyFilename', async () => {
+            const accountId = 'google_sa_tilde';
+            vi.mocked(configModule.loadConfig).mockResolvedValue({
+                accounts: {
+                    [accountId]: {
+                        id: accountId,
+                        engine: 'google',
+                        alias: 'sa-tilde',
+                        serviceAccountPath: '~/keys/sa.json'
+                    }
+                }
+            });
+
+            await getSearchConsoleClient(undefined, accountId);
+            expect(MockGoogleAuth).toHaveBeenCalledWith(expect.objectContaining({
+                keyFilename: join(homedir(), 'keys', 'sa.json')
             }));
         });
 


### PR DESCRIPTION
## Problem

Follow-up to #108 (the `expandHome` refactor). PR #108 fixed corruption of *absolute* paths with embedded tildes, but there is a separate latent bug: when `account.serviceAccountPath` is `~/key.json`, the readability guards (`isServiceAccountKeyMissing` / `assertServiceAccountKeyReadable`) expand the `~` for the **filesystem check only** — the expanded path is never written back.

At client construction, the **raw** `serviceAccountPath` was passed straight to `keyFilename`:

- `src/ga4/client.ts` → `BetaAnalyticsDataClient({ keyFilename: account.serviceAccountPath })`
- `src/google/client.ts:77` → `google.auth.GoogleAuth({ keyFilename: account.serviceAccountPath })` (Search Console)
- `src/google/client.ts:176` → `GoogleAuth({ keyFilename: account.serviceAccountPath })` (Indexing)

[google-auth-library does not expand `~`](https://github.com/googleapis/google-auth-library-nodejs) — it resolves `keyFilename` literally via `path.resolve`. So a `~/...` key **passes** the readability check (file exists) but then **fails** at client construction with a confusing file-not-found / auth error, because the path resolves to `~/key.json` as a literal name.

## Fix

Normalize with the shared `expandHome()` helper (from #108) at all three service-account construction sites so the path handed to the credential library always matches the path used by the readability check.

## Tests

Added a regression test in `tests/google-client.test.ts` asserting `GoogleAuth` receives the expanded `keyFilename` (home-dir path) for a `~/keys/sa.json` account. Verified it fails on the previous code and passes after.

- `tsc --noEmit` clean
- Full suite: 597 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Service account key paths beginning with `~` are now correctly expanded to the user’s home directory for Google Analytics, Search Console, and Indexing integrations.
  - Improved authentication setup when credentials are configured using home-directory shorthand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->